### PR TITLE
Correcting protobuf-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>2.4.1</version>
+			<version>2.3.0</version>
 			<scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Downgraded the protobuf-java version to 2.3.0 so resolve compilation issues.  Both 2.4.1 and 2.5.0 fail to generate and compile properly.
