### PR TITLE
Add a contructor to RiemannReporter which accepts a RiemannClient

### DIFF
--- a/src/main/java/com/yammer/metrics/reporting/RiemannReporter.java
+++ b/src/main/java/com/yammer/metrics/reporting/RiemannReporter.java
@@ -116,9 +116,13 @@ public class RiemannReporter extends AbstractPollingReporter implements MetricPr
     }
 
     public RiemannReporter(final Config c) throws IOException {
-        super(c.metricsRegistry, c.name);
-        this.riemann = RiemannClient.tcp(new InetSocketAddress(c.host, c.port));
+        this(c, RiemannClient.tcp(new InetSocketAddress(c.host, c.port)));
         riemann.connect();
+    }
+
+    public RiemannReporter(final Config c, final RiemannClient riemann) {
+        super(c.metricsRegistry, c.name);
+        this.riemann = riemann;
         this.c = c;
     }
 


### PR DESCRIPTION
Add a contructor to RiemannReporter which accepts a RiemannClient. This supports the use of clients alternate to the TCP client. In my particular case, I want to use a UDP client
