### PR TITLE
better error message in queue backwards compatability

### DIFF
--- a/src/main/java/com/aphyr/riemann/client/RiemannBatchClient.java
+++ b/src/main/java/com/aphyr/riemann/client/RiemannBatchClient.java
@@ -37,6 +37,7 @@ import java.util.List;
 import com.aphyr.riemann.Proto.Msg;
 import com.aphyr.riemann.Proto.Event;
 import com.aphyr.riemann.client.AbstractTransferQueue;
+import java.lang.RuntimeException;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
@@ -76,6 +77,7 @@ public class RiemannBatchClient extends AbstractRiemannClient {
       buffer = klass.asSubclass(AbstractTransferQueue.class).newInstance();
     } catch (Exception e) {
       buffer = null;
+      throw new RuntimeException("Failed casting " + klass.toString() + " to " + AbstractTransferQueue.class.toString(), e);
     }
     this.buffer = buffer;
   }


### PR DESCRIPTION
I hit this in production recently, and it was somewhat confusing to debug why riemann was sending no events after switching to the batch client. I eventually traced it here, and figured a better error message was in order rather than a client that just silently swallows all events and never sends them.

As a side note, this error case _always_ fires for me, and I'm not sure how the code is even meant to work. `.asSubclass` is called to turn `LinkedTransferQueue` into an `AbstractTransferQueue`. As I understand `asSubclass` though, this can't ever work, because `LinkedTransferQueue` is not an `AbstractTransferQueue`. Running the equivalent clojure code:

``` clojure
(.asSubclass (Class/forName "java.util.concurrent.LinkedTransferQueue") com.aphyr.riemann.client.AbstractTransferQueue)
```

always throws a class casting exception (at least in this jvm):

jvm info:

```
$ java -version
java version "1.7.0_45"
Java(TM) SE Runtime Environment (build 1.7.0_45-b18)
Java HotSpot(TM) 64-Bit Server VM (build 24.45-b08, mixed mode)
```
