### PR TITLE
fix riemann batch client, remove support for java 1.6

### DIFF
--- a/src/main/java/com/aphyr/riemann/client/AbstractTransferQueue.java
+++ b/src/main/java/com/aphyr/riemann/client/AbstractTransferQueue.java
@@ -1,9 +1,0 @@
-package com.aphyr.riemann.client;
-
-import java.util.Collection;
-
-public abstract class AbstractTransferQueue<E> {
-  public abstract int drainTo(Collection<? super E> c);
-  public abstract int drainTo(Collection<? super E> c, int maxElements);
-  public abstract void put(E e);
-}

--- a/src/main/java/com/aphyr/riemann/client/RiemannBatchClient.java
+++ b/src/main/java/com/aphyr/riemann/client/RiemannBatchClient.java
@@ -30,21 +30,18 @@ package com.aphyr.riemann.client;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-//import java.util.concurrent.LinkedTransferQueue;
-//import jsr166y.LinkedTransferQueue;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.ArrayList;
 import java.util.List;
 import com.aphyr.riemann.Proto.Msg;
 import com.aphyr.riemann.Proto.Event;
-import com.aphyr.riemann.client.AbstractTransferQueue;
-import java.lang.RuntimeException;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
 public class RiemannBatchClient extends AbstractRiemannClient {
   public final int batchSize;
   public final AtomicInteger bufferSize = new AtomicInteger();
-  public final AbstractTransferQueue<Write> buffer;
+  public final LinkedTransferQueue<Write> buffer;
   public final AbstractRiemannClient client;
 
   // Maximum time, in ms, we can wait for an event to be processed.
@@ -62,24 +59,7 @@ public class RiemannBatchClient extends AbstractRiemannClient {
       client) throws UnknownHostException, UnsupportedJVMException {
     this.batchSize = batchSize;
     this.client = client;
-    Class<?> klass = null;
-    try {
-      klass = Class.forName("java.util.concurrent.LinkedTransferQueue");
-    } catch (ClassNotFoundException e) {
-      try {
-        klass = Class.forName("jsr166y.LinkedTransferQueue");
-      } catch (ClassNotFoundException e2) {
-        throw new UnsupportedJVMException();
-      }
-    }
-    AbstractTransferQueue<Write> buffer;
-    try {
-      buffer = klass.asSubclass(AbstractTransferQueue.class).newInstance();
-    } catch (Exception e) {
-      buffer = null;
-      throw new RuntimeException("Failed casting " + klass.toString() + " to " + AbstractTransferQueue.class.toString(), e);
-    }
-    this.buffer = buffer;
+    this.buffer = new java.util.concurrent.LinkedTransferQueue<Write>();
   }
 
   // Fire and forget. No guarantees on delivery.


### PR DESCRIPTION
This was pretty broken, and 1.6 is deprecated now.

Only last gotcha with the batch client is that with a low throughput rate and a high batch size, your events might get super delayed. Currently users can fix that by running their own scheduler thread that calls flush, but we should probably do that here as well. Seems like a thing for another pull request though
