### PR TITLE
fixed adding attributes in bulk

### DIFF
--- a/src/main/java/com/aphyr/riemann/client/EventDSL.java
+++ b/src/main/java/com/aphyr/riemann/client/EventDSL.java
@@ -153,7 +153,7 @@ public class EventDSL {
     }
 
     public EventDSL attributes(Map<String, String> attributes) {
-      attributes.putAll(attributes);
+      this.attributes.putAll(attributes);
       return this;
     }
 


### PR DESCRIPTION
this keyword was missing causing attributes to be added to map in method argument instead of map in class
workaround: call putAll on the field directly
