### PR TITLE
Package riemann-java-client as Osgi bundle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
             <configuration>
                 <instructions>
                     <Export-Package>
+                        com.aphyr.riemann;-noimport:=true,
                         com.aphyr.riemann.client;-noimport:=true,
                         com.codahale.metrics.riemann;-noimport:=true,
                         com.yammer.metrics.reporting;-noimport:=true


### PR DESCRIPTION
In order to use the riemann-java-client in an Osgi environment (like Eclipse Virgo), the riemann-java-client should be packaged as an osgi module.

There is a maven plugin from apache felix to package Jar as Osgi bundles and so I accordingly changed the pom.xml file to package the java client as a bundle.

The only change to the jar artifact is the MANIFEST.FM file, that will contains osgi information.

I made the imports for com.codahale.metrics and com.yammer.metrics optional, as it seems that they are not required for simple use of the client. Is it correct?
