### PR TITLE
Add option to control DNS caching.

### DIFF
--- a/src/main/java/com/aphyr/riemann/client/CachingResolver.java
+++ b/src/main/java/com/aphyr/riemann/client/CachingResolver.java
@@ -1,0 +1,13 @@
+package com.aphyr.riemann.client;
+
+import java.net.InetSocketAddress;
+
+public class CachingResolver extends Resolver {
+  public CachingResolver(InetSocketAddress remote) {
+    super(remote);
+  }
+
+  public InetSocketAddress resolve() {
+    return this.remote;
+  }
+}

--- a/src/main/java/com/aphyr/riemann/client/ReconnectHandler.java
+++ b/src/main/java/com/aphyr/riemann/client/ReconnectHandler.java
@@ -46,7 +46,8 @@ public class ReconnectHandler extends SimpleChannelUpstreamHandler {
   }
 
   InetSocketAddress getRemoteAddress() {
-    return (InetSocketAddress) bootstrap.getOption("remoteAddress");
+    Resolver resolver = (Resolver) bootstrap.getOption("resolver");
+    return resolver.resolve();
   }
 
   @Override
@@ -63,9 +64,13 @@ public class ReconnectHandler extends SimpleChannelUpstreamHandler {
       timer.newTimeout(new TimerTask() {
         public void run(Timeout timeout) throws Exception {
           if (bootstrap instanceof ClientBootstrap) {
-            ((ClientBootstrap) bootstrap).connect();
+            ClientBootstrap b = (ClientBootstrap) bootstrap;
+            b.setOption("remoteAddress", getRemoteAddress());
+            b.connect();
           } else if (bootstrap instanceof ConnectionlessBootstrap) {
-            ((ConnectionlessBootstrap) bootstrap).connect();
+            ConnectionlessBootstrap b = (ConnectionlessBootstrap) bootstrap;
+            b.setOption("remoteAddress", getRemoteAddress());
+            b.connect();
           }
         }
       }, delay.get(), unit);

--- a/src/main/java/com/aphyr/riemann/client/Resolver.java
+++ b/src/main/java/com/aphyr/riemann/client/Resolver.java
@@ -1,0 +1,15 @@
+package com.aphyr.riemann.client;
+
+import java.net.InetSocketAddress;
+
+public class Resolver {
+  protected InetSocketAddress remote;
+
+  public Resolver(InetSocketAddress remote) {
+    this.remote = remote;
+  }
+
+  public InetSocketAddress resolve() {
+    return new InetSocketAddress(this.remote.getHostString(), this.remote.getPort());
+  }
+}


### PR DESCRIPTION
Adds connect(bool), which allows the user to control whether riemann-java-client will cache the address of the remote host or not.

The current behavior (resolve on creation) is desirable in some environments, but not in others (i.e. EC2) where the IP-address of the remote may change and is not controlled by the user.
