### PR TITLE
[Work in progress] use Netty 4

### DIFF
--- a/riemann-java-client/pom.xml
+++ b/riemann-java-client/pom.xml
@@ -40,8 +40,8 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>3.6.1.Final</version>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.4.Final</version>
         </dependency>
 
     </dependencies>

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/ChannelGroupHandler.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/ChannelGroupHandler.java
@@ -1,15 +1,14 @@
 package io.riemann.riemann.client;
 
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ChannelStateEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.channel.group.ChannelGroup;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.group.ChannelGroup;
 
 /**
  * Keep track of open channel(s)
  *
  */
-public class ChannelGroupHandler extends SimpleChannelUpstreamHandler {
+public class ChannelGroupHandler extends ChannelInboundHandlerAdapter {
 
   // A channel group so we can keep track of open channels.
   public final ChannelGroup channelGroup;
@@ -20,16 +19,15 @@ public class ChannelGroupHandler extends SimpleChannelUpstreamHandler {
 
   // When we open, add our channel to the channel group.
   @Override
-  public void channelOpen(ChannelHandlerContext c, ChannelStateEvent e) throws Exception {
-    channelGroup.add(e.getChannel());
-    super.channelOpen(c, e);
+  public void channelActive(ChannelHandlerContext c) throws Exception {
+    channelGroup.add(c.channel());
+    super.channelActive(c);
   }
 
   @Override
-  public void channelClosed(ChannelHandlerContext c, ChannelStateEvent e) throws Exception {
-    // Remove us from the channel group
-    channelGroup.remove(e.getChannel());
-    super.channelClosed(c, e);
+  public void channelInactive(ChannelHandlerContext c) throws Exception {
+    channelGroup.remove(c.channel());
+    super.channelInactive(c);
   }
 
 }

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/HashedWheelTimerFactory.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/HashedWheelTimerFactory.java
@@ -1,6 +1,6 @@
 package io.riemann.riemann.client;
 
-import org.jboss.netty.util.HashedWheelTimer;
+import io.netty.util.HashedWheelTimer;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/ReconnectHandler.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/ReconnectHandler.java
@@ -4,90 +4,68 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 import java.net.*;
 
-import org.jboss.netty.util.*;
-import org.jboss.netty.channel.*;
-import org.jboss.netty.bootstrap.Bootstrap;
-import org.jboss.netty.bootstrap.ClientBootstrap;
-import org.jboss.netty.bootstrap.ConnectionlessBootstrap;
-import org.jboss.netty.handler.timeout.*;
+import io.netty.util.*;
+import io.netty.channel.*;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.handler.timeout.*;
 import io.riemann.riemann.Proto.Msg;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class ReconnectHandler extends SimpleChannelUpstreamHandler {
+public class ReconnectHandler extends ChannelInboundHandlerAdapter {
   final Bootstrap bootstrap;
   public final Timer timer;
   public long startTime = -1;
   public final AtomicLong delay;
   public final TimeUnit unit;
+  public final Resolver resolver;
 
-  public ReconnectHandler(ClientBootstrap bootstrap, Timer timer, AtomicLong delay, TimeUnit unit) {
+  public ReconnectHandler(Bootstrap bootstrap, Timer timer, AtomicLong delay, TimeUnit unit, Resolver resolver) {
     this.bootstrap = bootstrap;
     this.timer = timer;
     this.delay = delay;
     this.unit = unit;
-  }
-  
-  public ReconnectHandler(ConnectionlessBootstrap bootstrap, Timer timer, AtomicLong delay, TimeUnit unit) {
-    this.bootstrap = bootstrap;
-    this.timer = timer;
-    this.delay = delay;
-    this.unit = unit;
+    this.resolver = resolver;
   }
 
   InetSocketAddress getRemoteAddress() {
-    Resolver resolver = (Resolver) bootstrap.getOption("resolver");
     return resolver.resolve();
   }
 
   @Override
-  public void channelDisconnected(ChannelHandlerContext c, ChannelStateEvent e) throws Exception {
-    // Go ahead and close. I don't know why Netty doesn't close disconnected
-    // TCP sockets, but it seems not to.
-    e.getChannel().close();
-    super.channelDisconnected(c, e);
-  }
-
-  @Override
-  public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
+  public void channelInactive(ChannelHandlerContext c) {
+    c.channel().close();
     try {
       timer.newTimeout(new TimerTask() {
         public void run(Timeout timeout) throws Exception {
-          if (bootstrap instanceof ClientBootstrap) {
-            ClientBootstrap b = (ClientBootstrap) bootstrap;
-            b.setOption("remoteAddress", getRemoteAddress());
-            b.connect();
-          } else if (bootstrap instanceof ConnectionlessBootstrap) {
-            ConnectionlessBootstrap b = (ConnectionlessBootstrap) bootstrap;
-            b.setOption("remoteAddress", getRemoteAddress());
-            b.connect();
-          }
+          bootstrap.remoteAddress(getRemoteAddress());
+          bootstrap.connect();
+
         }
       }, delay.get(), unit);
     } catch (java.lang.IllegalStateException ex) {
       // The timer must have been stopped.
     }
-    super.channelClosed(ctx, e);
+    // super.channelInactive(c); TODO
   }
 
+
   @Override
-  public void channelConnected(ChannelHandlerContext c, ChannelStateEvent e) throws Exception {
+  public void channelActive(ChannelHandlerContext c) throws Exception {
     if (startTime < 0) {
       startTime = System.currentTimeMillis();
     }
-    super.channelConnected(c, e);
+    super.channelActive(c);
   }
 
   @Override
-  public void exceptionCaught(ChannelHandlerContext c, ExceptionEvent e) {
-    final Throwable cause = e.getCause();
-
+  public void exceptionCaught(ChannelHandlerContext c, Throwable cause) {
     if (cause instanceof ConnectException) {
       startTime = -1;
     } else if (cause instanceof ReadTimeoutException) {
       // The connection was OK but there was no traffic for the last period.
     } else {
-     c.sendUpstream(e);
+     c.fireChannelRead(c); // TODO c in parameter ?
     }
-    c.getChannel().close();
+    c.channel().close();
   }
 }

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/TcpClientTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/TcpClientTest.java
@@ -129,6 +129,9 @@ public class TcpClientTest {
         t0 = System.nanoTime();
         responses.add(client.event().service("slow").metric(i).send());
         latency = System.nanoTime() - t0;
+        if(latency > 100000000 ) {
+          System.out.println("i : " + i + " ; " + latency);
+        }
         assertTrue(latency <= 100000000);
       }
 


### PR DESCRIPTION
#73

Disclaimer : I never used Netty before.

This is a tentative to update the client to Netty 4. This code compile but doesn't work.
My biggest problem is with the TcpHandler (my code is wrong) :

The Netty 3 code extends SimpleChannelHandler, and override **handleDownstream** and **messageReceived**. I cannot reproduced this behavior in Netty 4 because SimpleChannelHandler not longer exists. In other classes, **handleDownstream** is now divided into several methods (in ChannelOutboundHandlerAdapter for example, we can use the **write** method if i understand correctly), and **messageReceived** is now (i think) channelRead0 (in **SimpleChannelInboundHandler**)

 I tried to use ChannelOutboundHandlerAdapter, SimpleChannelInboundHandler etc... but it is not working. I think it is because the Inbound/Outbound separation in Netty 4. 

I opened the PR so you can look at my code, i need help from someone with netty skills ;)
