### PR TITLE
Add time_micros field in Event

### DIFF
--- a/riemann-java-client/src/main/proto/riemann/proto.proto
+++ b/riemann-java-client/src/main/proto/riemann/proto.proto
@@ -24,6 +24,7 @@ message Event {
   optional float ttl = 8;
   repeated Attribute attributes = 9;
 
+  optional int64 time_micros = 10;
   optional sint64 metric_sint64 = 13;
   optional double metric_d = 14;
   optional float metric_f = 15;


### PR DESCRIPTION
The time_micros field allows clients to send time in microseconds.
