### PR TITLE
Add possibility to set packets source address/port in case of server with multiple interfaces

### DIFF
--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/RiemannClient.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/RiemannClient.java
@@ -48,38 +48,62 @@ public class RiemannClient implements IRiemannClient {
   }
 
   // TCP constructors
-  public static RiemannClient tcp(final InetSocketAddress address) throws IOException {
-    return wrap(new TcpTransport(address));
+  public static RiemannClient tcp(final InetSocketAddress remoteAddress) throws IOException {
+    return wrap(new TcpTransport(remoteAddress));
   }
 
-  public static RiemannClient tcp(final String host, final int port) throws IOException{
-    return wrap(new TcpTransport(host, port));
+  public static RiemannClient tcp(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) throws IOException {
+    return wrap(new TcpTransport(remoteAddress,localAddress));
   }
 
-  public static RiemannClient tcp(final String host) throws IOException {
-    return wrap(new TcpTransport(host));
+  public static RiemannClient tcp(final String remoteHost, final int remotePort) throws IOException{
+    return wrap(new TcpTransport(remoteHost, remotePort));
   }
 
-  public static RiemannClient tcp(final int port) throws IOException {
-    return wrap(new TcpTransport(port));
+  public static RiemannClient tcp(final String remoteHost, final int remotePort, final String localHost, final int localPort) throws IOException{
+    return wrap(new TcpTransport(remoteHost, remotePort, localHost, localPort));
+  }
+
+  public static RiemannClient tcp(final String remoteHost) throws IOException {
+    return wrap(new TcpTransport(remoteHost));
+  }
+
+  public static RiemannClient tcp(final String remoteHost, final String localHost) throws IOException {
+    return wrap(new TcpTransport(remoteHost, localHost));
+  }
+
+  public static RiemannClient tcp(final int remotePort) throws IOException {
+    return wrap(new TcpTransport(remotePort));
   }
 
   // UDP constructors
   // STOP REPEATING YOURSELF KYLE! STOP REPEATING YOURSELF KYLE!
-  public static RiemannClient udp(final InetSocketAddress address) throws IOException {
-    return wrap(new UdpTransport(address));
+  public static RiemannClient udp(final InetSocketAddress remoteAddress) throws IOException {
+    return wrap(new UdpTransport(remoteAddress));
   }
 
-  public static RiemannClient udp(final String host, final int port) throws IOException {
-    return wrap(new UdpTransport(host, port));
+  public static RiemannClient udp(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) throws IOException {
+    return wrap(new UdpTransport(remoteAddress,localAddress));
   }
 
-  public static RiemannClient udp(final String host) throws IOException {
-    return wrap(new UdpTransport(host));
+  public static RiemannClient udp(final String remoteHost, final int remotePort) throws IOException {
+    return wrap(new UdpTransport(remoteHost, remotePort));
   }
 
-  public static RiemannClient udp(final int port) throws IOException {
-    return wrap(new UdpTransport(port));
+  public static RiemannClient udp(final String remoteHost, final int remotePort, final String localHost, final int localPort) throws IOException{
+    return wrap(new UdpTransport(remoteHost, remotePort, localHost, localPort));
+  }
+
+  public static RiemannClient udp(final String remoteHost) throws IOException {
+    return wrap(new UdpTransport(remoteHost));
+  }
+
+  public static RiemannClient udp(final String remoteHost, final String localHost) throws IOException {
+    return wrap(new UdpTransport(remoteHost, localHost));
+  }
+
+  public static RiemannClient udp(final int remotePort) throws IOException {
+    return wrap(new UdpTransport(remotePort));
   }
 
 

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/SimpleUdpTransport.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/SimpleUdpTransport.java
@@ -15,22 +15,38 @@ public class SimpleUdpTransport implements SynchronousTransport {
   private volatile DatagramSocket socket;
   private volatile boolean connected = false;
 
-  private final InetSocketAddress address;
+  private final InetSocketAddress remoteAddress;
+  private final InetSocketAddress localAddress;
 
   private volatile Resolver resolver;
+  private volatile Resolver localResolver;
 
   public volatile boolean cacheDns = true;
 
-  public SimpleUdpTransport(final InetSocketAddress address) {
-    this.address = address;
+  public SimpleUdpTransport(final InetSocketAddress remoteAddress) {
+    this.remoteAddress = remoteAddress;
+    this.localAddress = null;
+  }
+
+  public SimpleUdpTransport(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
+    this.remoteAddress = remoteAddress;
+    this.localAddress = localAddress;
   }
 
   public SimpleUdpTransport(final String host, final int port) throws IOException {
     this(new InetSocketAddress(host, port));
   }
 
+  public SimpleUdpTransport(final String remoteHost, final int remotePort, final String localHost, final int localPort) throws IOException {
+    this(new InetSocketAddress(remoteHost, remotePort), new InetSocketAddress(localHost, localPort) );
+  }
+
   public SimpleUdpTransport(final String host) throws IOException {
     this(host, DEFAULT_PORT);
+  }
+
+  public SimpleUdpTransport(final String remoteHost, final String localHost) throws IOException {
+    this(remoteHost, DEFAULT_PORT, localHost, DEFAULT_PORT);
   }
 
   public SimpleUdpTransport(final int port) throws IOException {
@@ -54,11 +70,21 @@ public class SimpleUdpTransport implements SynchronousTransport {
   @Override
   public synchronized void connect() throws IOException {
     if (cacheDns == true) {
-      this.resolver = new CachingResolver(address);
+      this.resolver = new CachingResolver(remoteAddress);
+      if( this.localAddress != null){
+        this.localResolver = new CachingResolver(localAddress);
+      }
     } else {
-      this.resolver = new Resolver(address);
+      this.resolver = new Resolver(remoteAddress);
+      if( this.localAddress != null){
+        this.localResolver = new Resolver(localAddress);
+      }
     }
-    socket = new DatagramSocket();
+    if (this.localAddress != null){
+      socket = new DatagramSocket(localResolver.resolve());
+    }else{
+      socket = new DatagramSocket();
+    }
     connected = true;
   }
 

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/SimpleUdpTransport.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/SimpleUdpTransport.java
@@ -46,7 +46,7 @@ public class SimpleUdpTransport implements SynchronousTransport {
   }
 
   public SimpleUdpTransport(final String remoteHost, final String localHost) throws IOException {
-    this(remoteHost, DEFAULT_PORT, localHost, DEFAULT_PORT);
+    this(remoteHost, DEFAULT_PORT, localHost, 0);
   }
 
   public SimpleUdpTransport(final int port) throws IOException {

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/TcpTransport.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/TcpTransport.java
@@ -83,7 +83,7 @@ public class TcpTransport implements AsynchronousTransport {
 
   public TcpTransport(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
     this.remoteAddress = remoteAddress;
-    this.localAddress = remoteAddress;
+    this.localAddress = localAddress;
   }
 
   public TcpTransport(final String remoteHost, final int remotePort) throws IOException {
@@ -99,7 +99,7 @@ public class TcpTransport implements AsynchronousTransport {
   }
 
   public TcpTransport(final String remoteHost, final String localHost) throws IOException {
-    this(remoteHost, DEFAULT_PORT, localHost, DEFAULT_PORT);
+    this(remoteHost, DEFAULT_PORT, localHost, 0);
   }
 
   public TcpTransport(final int remotePort) throws IOException {

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/TcpTransport.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/TcpTransport.java
@@ -61,7 +61,8 @@ public class TcpTransport implements AsynchronousTransport {
   public final AtomicInteger writeBufferHigh = new AtomicInteger(1024 * 64);
   public final AtomicInteger writeBufferLow  = new AtomicInteger(1024 * 8);
   public final AtomicBoolean cacheDns = new AtomicBoolean(true);
-  public final InetSocketAddress address;
+  public final InetSocketAddress remoteAddress;
+  public final InetSocketAddress localAddress;
   public final AtomicReference<SSLContext> sslContext =
     new AtomicReference<SSLContext>();
 
@@ -75,20 +76,34 @@ public class TcpTransport implements AsynchronousTransport {
     this.exceptionReporter = exceptionReporter;
   }
 
-  public TcpTransport(final InetSocketAddress address) {
-    this.address = address;
+  public TcpTransport(final InetSocketAddress remoteAddress) {
+    this.remoteAddress = remoteAddress;
+    this.localAddress = null;
   }
 
-  public TcpTransport(final String host, final int port) throws IOException {
-    this(new InetSocketAddress(host, port));
+  public TcpTransport(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
+    this.remoteAddress = remoteAddress;
+    this.localAddress = remoteAddress;
   }
 
-  public TcpTransport(final String host) throws IOException {
-    this(host, DEFAULT_PORT);
+  public TcpTransport(final String remoteHost, final int remotePort) throws IOException {
+    this(new InetSocketAddress(remoteHost, remotePort));
   }
 
-  public TcpTransport(final int port) throws IOException {
-    this(InetAddress.getLocalHost().getHostAddress(), port);
+  public TcpTransport(final String remoteHost, final int remotePort, final String localHost, final int localPort) throws IOException {
+    this(new InetSocketAddress(remoteHost, remotePort),new InetSocketAddress(localHost, localPort) );
+  }
+
+  public TcpTransport(final String remoteHost) throws IOException {
+    this(remoteHost, DEFAULT_PORT);
+  }
+
+  public TcpTransport(final String remoteHost, final String localHost) throws IOException {
+    this(remoteHost, DEFAULT_PORT, localHost, DEFAULT_PORT);
+  }
+
+  public TcpTransport(final int remotePort) throws IOException {
+    this(InetAddress.getLocalHost().getHostAddress(), remotePort);
   }
 
 
@@ -189,10 +204,17 @@ public class TcpTransport implements AsynchronousTransport {
 
 
     Resolver resolver;
+    Resolver localResolver = null;
     if (cacheDns.get() == true) {
-      resolver = new CachingResolver(address);
+        resolver = new CachingResolver(remoteAddress);
+      if(localAddress != null){
+        localResolver = new CachingResolver(localAddress);
+      }
     } else {
-      resolver = new Resolver(address);
+      resolver = new Resolver(remoteAddress);
+      if( localAddress != null){
+        localResolver = new Resolver(localAddress);
+      }
     }
 
     // Set bootstrap options
@@ -203,6 +225,9 @@ public class TcpTransport implements AsynchronousTransport {
     bootstrap.setOption("writeBufferHighWaterMark", writeBufferHigh.get());
     bootstrap.setOption("resolver", resolver);
     bootstrap.setOption("remoteAddress", resolver.resolve());
+    if( localAddress != null){
+      bootstrap.setOption("localAddress", localResolver.resolve());
+    }
 
     // Connect and wait for connection ready
     final ChannelFuture result = bootstrap.connect().awaitUninterruptibly();

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/UdpTransport.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/UdpTransport.java
@@ -83,7 +83,7 @@ public class UdpTransport implements SynchronousTransport {
   }
 
   public UdpTransport(final String remoteHost, final String localHost) throws IOException {
-    this(remoteHost, DEFAULT_PORT, localHost, DEFAULT_PORT);
+    this(remoteHost, DEFAULT_PORT, localHost, 0);
   }
 
   public UdpTransport(final int port) throws IOException {


### PR DESCRIPTION
We use clojure riemann client to monitor some gateway servers with multiple interface, including VPN interfaces with non routed subnet (for interconnection). So we need to specify source address for tcp-transport.

I include the change in udp-transport because firewall could/should drop packets coming from non routed network.