### PR TITLE
Set time_micros in EventDSL

### DIFF
--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/EventDSL.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/EventDSL.java
@@ -68,11 +68,13 @@ public class EventDSL {
 
     public EventDSL time(float time) {
         builder.setTime((long) time);
+        builder.setTimeMicros((long) (time * 1000000));
         return this;
     }
 
     public EventDSL time(double time) {
         builder.setTime((long) time);
+        builder.setTimeMicros((long) (time * 1000000));
         return this;
     }
     public EventDSL time(long time) {


### PR DESCRIPTION
Set time_micros in EventDSL when the `time` fn receives a float or a double.