### PR TITLE
Adding license information to the pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+         
+    <licenses>
+      <license>
+        <name>Apache-2.0</name>
+        <url>https://choosealicense.com/licenses/apache-2.0/</url>
+      </license>
+    </licenses>
 
     <dependencies>
         <!-- TEST DEP's -->


### PR DESCRIPTION
The license information should be part of the pom.xml. That way other open source tools like [VersionEye](https://www.versioneye.com) can read the license and handle it. 