### PR TITLE
Adds an EventBuilder to dissociate the DSL/builder from the client

### DIFF
--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/EventBuilder.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/EventBuilder.java
@@ -1,0 +1,165 @@
+package io.riemann.riemann.client;
+
+import io.riemann.riemann.Proto;
+import io.riemann.riemann.Proto.Attribute;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EventBuilder {
+    private final Proto.Event.Builder builder;
+    private final Map<String, String> attributes = new HashMap<String, String>();
+
+    public EventBuilder() {
+        this.builder = Proto.Event.newBuilder();
+    }
+
+    public EventBuilder host(String host) {
+        if (null == host) {
+            builder.clearHost();
+        } else {
+            builder.setHost(host);
+        }
+        return this;
+    }
+
+    public EventBuilder service(String service) {
+        if (null == service) {
+            builder.clearService();
+        } else {
+            builder.setService(service);
+        }
+        return this;
+    }
+
+    public EventBuilder state(String state) {
+        if (null == state) {
+            builder.clearState();
+        } else {
+            builder.setState(state);
+        }
+        return this;
+    }
+
+    public EventBuilder description(String description) {
+        if (null == description) {
+            builder.clearDescription();
+        } else {
+            builder.setDescription(description);
+        }
+        return this;
+    }
+
+    public EventBuilder time() {
+        builder.clearMetricF();
+        return this;
+    }
+
+    public EventBuilder time(float time) {
+        builder.setTime((long) time);
+        builder.setTimeMicros((long) (time * 1000000));
+        return this;
+    }
+
+    public EventBuilder time(double time) {
+        builder.setTime((long) time);
+        builder.setTimeMicros((long) (time * 1000000));
+        return this;
+    }
+
+    public EventBuilder time(long time) {
+        builder.setTime(time);
+        return this;
+    }
+
+    public EventBuilder metric() {
+        builder.clearMetricF();
+        builder.clearMetricD();
+        builder.clearMetricSint64();
+        return this;
+    }
+
+    public EventBuilder metric(byte metric) {
+        builder.setMetricSint64((long) metric);
+        builder.setMetricF((float) metric);
+        return this;
+    }
+
+    public EventBuilder metric(short metric) {
+        builder.setMetricSint64((long) metric);
+        builder.setMetricF((float) metric);
+        return this;
+    }
+
+    public EventBuilder metric(int metric) {
+        builder.setMetricSint64((long) metric);
+        builder.setMetricF((float) metric);
+        return this;
+    }
+
+    public EventBuilder metric(long metric) {
+        builder.setMetricSint64(metric);
+        builder.setMetricF((float) metric);
+        return this;
+    }
+
+    public EventBuilder metric(float metric) {
+        builder.setMetricF(metric);
+        return this;
+    }
+
+    public EventBuilder metric(double metric) {
+        builder.setMetricD(metric);
+        builder.setMetricF((float) metric);
+        return this;
+    }
+
+    public EventBuilder tag(String tag) {
+        builder.addTags(tag);
+        return this;
+    }
+
+    public EventBuilder tags(List<String> tags) {
+        builder.addAllTags(tags);
+        return this;
+    }
+
+    public EventBuilder tags(String... tags) {
+        builder.addAllTags(Arrays.asList(tags));
+        return this;
+    }
+
+    public EventBuilder ttl() {
+        builder.clearTtl();
+        return this;
+    }
+
+    public EventBuilder ttl(float ttl) {
+        builder.setTtl(ttl);
+        return this;
+    }
+
+    public EventBuilder attribute(String name, String value) {
+        attributes.put(name, value);
+        return this;
+    }
+
+    public EventBuilder attributes(Map<String, String> attributes) {
+        this.attributes.putAll(attributes);
+        return this;
+    }
+
+    // Returns the compiled Protobuf event for this DSL. Merges in the custom
+    // attributes map. Can only be called safely once.
+    public Proto.Event build() {
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            Attribute.Builder attribBuilder = Attribute.newBuilder();
+            attribBuilder.setKey(entry.getKey());
+            attribBuilder.setValue(entry.getValue());
+            builder.addAttributes(attribBuilder);
+        }
+        return builder.build();
+    }
+}

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/EventBuilder.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/EventBuilder.java
@@ -53,7 +53,8 @@ public class EventBuilder {
     }
 
     public EventBuilder time() {
-        builder.clearMetricF();
+        builder.clearTime();
+        builder.clearTimeMicros();
         return this;
     }
 

--- a/riemann-java-client/src/main/java/io/riemann/riemann/client/EventDSL.java
+++ b/riemann-java-client/src/main/java/io/riemann/riemann/client/EventDSL.java
@@ -11,14 +11,13 @@ import java.util.HashMap;
 
 public class EventDSL {
     public final IRiemannClient client;
-    public final Event.Builder builder;
-    public final Map<String, String> attributes = new HashMap<String, String>();
+    public final EventBuilder event;
 
     public EventDSL(IRiemannClient client) {
         this.client = client;
-        this.builder = Event.newBuilder();
+        this.event = new EventBuilder();
         try {
-            this.builder.setHost(java.net.InetAddress.getLocalHost().getHostName());
+            this.event.host(java.net.InetAddress.getLocalHost().getHostName());
         } catch (java.net.UnknownHostException e) {
             // If we can't get the local host, a null host is perfectly
             // acceptable.  Caller will know soon enough. :)
@@ -26,149 +25,118 @@ public class EventDSL {
     }
 
     public EventDSL host(String host) {
-        if (null == host) {
-            builder.clearHost();
-        } else {
-            builder.setHost(host);
-        }
+        this.event.host(host);
         return this;
     }
 
     public EventDSL service(String service) {
-        if (null == service) {
-            builder.clearService();
-        } else {
-            builder.setService(service);
-        }
+        this.event.service(service);
         return this;
     }
 
     public EventDSL state(String state) {
-        if (null == state) {
-            builder.clearState();
-        } else {
-            builder.setState(state);
-        }
+        this.event.state(state);
         return this;
     }
 
     public EventDSL description(String description) {
-        if (null == description) {
-            builder.clearDescription();
-        } else {
-            builder.setDescription(description);
-        }
+        this.event.description(description);
         return this;
     }
 
     public EventDSL time(Null n) {
-        builder.clearMetricF();
+        this.event.time();
         return this;
     }
 
     public EventDSL time(float time) {
-        builder.setTime((long) time);
-        builder.setTimeMicros((long) (time * 1000000));
+        this.event.time(time);
         return this;
     }
 
     public EventDSL time(double time) {
-        builder.setTime((long) time);
-        builder.setTimeMicros((long) (time * 1000000));
+        this.event.time(time);
         return this;
     }
     public EventDSL time(long time) {
-        builder.setTime(time);
+        this.event.time(time);
         return this;
     }
 
     public EventDSL metric(Null n) {
-        builder.clearMetricF();
-        builder.clearMetricD();
-        builder.clearMetricSint64();
+        this.event.metric();
         return this;
     }
 
     public EventDSL metric(byte metric) {
-      builder.setMetricSint64((long) metric);
-      builder.setMetricF((float) metric);
-      return this;
+        this.event.metric(metric);
+        return this;
     }
 
     public EventDSL metric(short metric) {
-      builder.setMetricSint64((long) metric);
-        builder.setMetricF((float) metric);
-      return this;
+        this.event.metric(metric);
+        return this;
     }
 
     public EventDSL metric(int metric) {
-        builder.setMetricSint64((long) metric);
-        builder.setMetricF((float) metric);
+        this.event.metric(metric);
         return this;
     }
 
     public EventDSL metric(long metric) {
-        builder.setMetricSint64(metric);
-        builder.setMetricF((float) metric);
+        this.event.metric(metric);
         return this;
     }
 
     public EventDSL metric(float metric) {
-      builder.setMetricF(metric);
-      return this;
+        this.event.metric(metric);
+        return this;
     }
 
     public EventDSL metric(double metric) {
-        builder.setMetricD(metric);
-        builder.setMetricF((float) metric);
+        this.event.metric(metric);
         return this;
     }
 
     public EventDSL tag(String tag) {
-        builder.addTags(tag);
+        this.event.tag(tag);
         return this;
     }
 
     public EventDSL tags(List<String> tags) {
-        builder.addAllTags(tags);
+        this.event.tags(tags);
         return this;
     }
 
     public EventDSL tags(String... tags) {
-        builder.addAllTags(Arrays.asList(tags));
+        this.event.tags(tags);
         return this;
     }
 
     public EventDSL ttl(Null n) {
-        builder.clearTtl();
+        this.event.ttl();
         return this;
     }
 
     public EventDSL ttl(float ttl) {
-        builder.setTtl(ttl);
+        this.event.ttl(ttl);
         return this;
     }
 
     public EventDSL attribute(String name, String value) {
-      attributes.put(name, value);
-      return this;
+        this.event.attribute(name, value);
+        return this;
     }
 
     public EventDSL attributes(Map<String, String> attributes) {
-      this.attributes.putAll(attributes);
-      return this;
+        this.event.attributes(attributes);
+        return this;
     }
 
     // Returns the compiled Protobuf event for this DSL. Merges in the custom
     // attributes map. Can only be called safely once.
     public Event build() {
-      for (Map.Entry<String, String> entry : attributes.entrySet()) {
-        Attribute.Builder attribBuilder = Attribute.newBuilder();
-        attribBuilder.setKey(entry.getKey());
-        attribBuilder.setValue(entry.getValue());
-        builder.addAttributes(attribBuilder);
-      }
-      return builder.build();
+        return this.event.build();
     }
 
     public IPromise<Msg> send() {

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/EventBuilderTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/EventBuilderTest.java
@@ -1,0 +1,30 @@
+package riemann.java.client.tests;
+
+import io.riemann.riemann.Proto;
+import io.riemann.riemann.client.EventBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventBuilderTest {
+
+    @Test
+    public void should_create_event() {
+        EventBuilder eventBuilder = new EventBuilder();
+        Proto.Event event = eventBuilder
+                .host("riemann.localhost")
+                .metric(42.2)
+                .service("cpu_percent_usage")
+                .state("fine")
+                .tags("high", "backend")
+                .description("Processor usage")
+                .attribute("health", "good")
+                .attribute("environment", "production")
+                .attribute("datacenter", "eu_west")
+                .ttl(60)
+                .build();
+        assertEquals("cpu_percent_usage", event.getService());
+        assertEquals("riemann.localhost", event.getHost());
+        assertEquals("fine", event.getState());
+    }
+}

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/EventBuilderTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/EventBuilderTest.java
@@ -1,8 +1,11 @@
 package riemann.java.client.tests;
 
+import com.google.protobuf.ProtocolStringList;
 import io.riemann.riemann.Proto;
 import io.riemann.riemann.client.EventBuilder;
 import org.junit.Test;
+
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -10,21 +13,151 @@ public class EventBuilderTest {
 
     @Test
     public void should_create_event() {
-        EventBuilder eventBuilder = new EventBuilder();
-        Proto.Event event = eventBuilder
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("network_zone", "dmz");
+        List<String> tags = new ArrayList<String>();
+        tags.add("fast");
+        Proto.Event event = new EventBuilder()
                 .host("riemann.localhost")
                 .metric(42.2)
                 .service("cpu_percent_usage")
                 .state("fine")
                 .tags("high", "backend")
+                .tag("storage")
+                .tags(tags)
                 .description("Processor usage")
                 .attribute("health", "good")
                 .attribute("environment", "production")
                 .attribute("datacenter", "eu_west")
+                .attributes(attributes)
                 .ttl(60)
                 .build();
+
         assertEquals("cpu_percent_usage", event.getService());
         assertEquals("riemann.localhost", event.getHost());
         assertEquals("fine", event.getState());
+        assertEquals(42.2, event.getMetricD(), 0D);
+        ProtocolStringList eventTags = event.getTagsList();
+        assertEquals(4, eventTags.size());
+        assertEquals("high", eventTags.get(0));
+        assertEquals("backend", eventTags.get(1));
+        assertEquals("storage", eventTags.get(2));
+        assertEquals("fast", eventTags.get(3));
+        assertEquals("Processor usage", event.getDescription());
+        List<Proto.Attribute> eventAttributes = getAttributesSortedByKey(event);
+        assertEquals(4, eventAttributes.size());
+        // datacenter -> eu_west
+        assertEquals("datacenter", eventAttributes.get(0).getKey());
+        assertEquals("eu_west", eventAttributes.get(0).getValue());
+        // environment -> production
+        assertEquals("environment", eventAttributes.get(1).getKey());
+        assertEquals("production", eventAttributes.get(1).getValue());
+        // health -> good
+        assertEquals("health", eventAttributes.get(2).getKey());
+        assertEquals("good", eventAttributes.get(2).getValue());
+        // health -> good
+        assertEquals("network_zone", eventAttributes.get(3).getKey());
+        assertEquals("dmz", eventAttributes.get(3).getValue());
+        assertEquals(60F, event.getTtl(), 0F);
+    }
+
+    @Test
+    public void should_create_event_with_metric_float() {
+        Proto.Event event = new EventBuilder()
+                .metric(123.4F)
+                .build();
+
+        assertEquals(123.4F, event.getMetricF(), 0F);
+    }
+
+    @Test
+    public void should_create_event_with_metric_int() {
+        Proto.Event event = new EventBuilder()
+                .metric(123)
+                .build();
+
+        assertEquals(123, event.getMetricSint64());
+    }
+
+    @Test
+    public void should_create_event_with_metric_short() {
+        Proto.Event event = new EventBuilder()
+                .metric((short) 1)
+                .build();
+
+        assertEquals(1, event.getMetricSint64());
+    }
+
+    @Test
+    public void should_create_event_with_metric_long() {
+        Proto.Event event = new EventBuilder()
+                .metric(1234567891011L)
+                .build();
+
+        assertEquals(1234567891011L, event.getMetricSint64());
+    }
+
+    @Test
+    public void should_create_event_with_metric_byte() {
+        Proto.Event event = new EventBuilder()
+                .metric((byte) 1)
+                .build();
+
+        assertEquals(1, event.getMetricSint64());
+    }
+
+    @Test
+    public void should_clear_metric() {
+        EventBuilder eventBuilder = new EventBuilder();
+        Proto.Event event = eventBuilder
+                .host("riemann.localhost")
+                .metric(123)
+                .metric()
+                .build();
+
+        assertEquals(false, event.hasMetricD());
+        assertEquals(false, event.hasMetricF());
+        assertEquals(false, event.hasMetricSint64());
+        assertEquals(0D, event.getMetricD(), 0D);
+        assertEquals(0F, event.getMetricF(), 0F);
+        assertEquals(0L, event.getMetricSint64(), 0L);
+    }
+
+    @Test
+    public void should_clear_time() {
+        EventBuilder eventBuilder = new EventBuilder();
+        Proto.Event event = eventBuilder
+                .host("riemann.localhost")
+                .time(System.currentTimeMillis())
+                .time()
+                .build();
+
+        assertEquals(false, event.hasTime());
+        assertEquals(0L, event.getTime());
+        assertEquals(0L, event.getTimeMicros());
+    }
+
+    @Test
+    public void should_clear_ttl() {
+        EventBuilder eventBuilder = new EventBuilder();
+        Proto.Event event = eventBuilder
+                .host("riemann.localhost")
+                .ttl(20)
+                .ttl()
+                .build();
+
+        assertEquals(false, event.hasTtl());
+        assertEquals(0F, event.getTtl(), 0F);
+    }
+
+    private List<Proto.Attribute> getAttributesSortedByKey(Proto.Event event) {
+        List<Proto.Attribute> attributes = new ArrayList<Proto.Attribute>(event.getAttributesList());
+        Collections.sort(attributes, new Comparator<Proto.Attribute>() {
+            @Override
+            public int compare(Proto.Attribute o1, Proto.Attribute o2) {
+                return o1.getKey().compareTo(o2.getKey());
+            }
+        });
+        return attributes;
     }
 }

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/EventBuilderTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/EventBuilderTest.java
@@ -46,18 +46,10 @@ public class EventBuilderTest {
         assertEquals("Processor usage", event.getDescription());
         List<Proto.Attribute> eventAttributes = getAttributesSortedByKey(event);
         assertEquals(4, eventAttributes.size());
-        // datacenter -> eu_west
-        assertEquals("datacenter", eventAttributes.get(0).getKey());
-        assertEquals("eu_west", eventAttributes.get(0).getValue());
-        // environment -> production
-        assertEquals("environment", eventAttributes.get(1).getKey());
-        assertEquals("production", eventAttributes.get(1).getValue());
-        // health -> good
-        assertEquals("health", eventAttributes.get(2).getKey());
-        assertEquals("good", eventAttributes.get(2).getValue());
-        // health -> good
-        assertEquals("network_zone", eventAttributes.get(3).getKey());
-        assertEquals("dmz", eventAttributes.get(3).getValue());
+        assertEqualsAttribute("datacenter", "eu_west", eventAttributes.get(0));
+        assertEqualsAttribute("environment", "production", eventAttributes.get(1));
+        assertEqualsAttribute("health", "good", eventAttributes.get(2));
+        assertEqualsAttribute("network_zone", "dmz", eventAttributes.get(3));
         assertEquals(60F, event.getTtl(), 0F);
     }
 
@@ -159,5 +151,10 @@ public class EventBuilderTest {
             }
         });
         return attributes;
+    }
+
+    private void assertEqualsAttribute(String expectedKey, String expectedValue, Proto.Attribute actual) {
+        assertEquals(expectedKey, actual.getKey());
+        assertEquals(expectedValue, actual.getValue());
     }
 }


### PR DESCRIPTION
The `EventDSL` is useful but at the same time the class is tightly coupled with the RiemannClient and the constructor is using `java.net.InetAddress.getLocalHost()` (which can make call to the DNS resolver... see #44).
Also in our context, we have a dedicated host that send events to Riemann (so the call to `java.net.InetAddress.getLocalHost()` is useless).

Using the low-level builder `Proto.Event.newBuilder()` as an alternative is a bit rough (at least for a newcomer).

As a result I've decided to create a new class named `EventBuilder` who's only job is to ease the creation of an `Event`. To avoid code duplication, `EventDSL` is using `EventBuilder`.
This change does not introduce a breaking change since the API of the `EventDSL` remains the same.

I've started to write one unit test (and I planned to write more and also add documentation) but before spending more time on it, I would like to hear from you. Are you OK with this change ?
