### PR TITLE
upgrade codahale version to 3.1.5

### DIFF
--- a/metrics3-riemann-reporter/pom.xml
+++ b/metrics3-riemann-reporter/pom.xml
@@ -13,9 +13,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.5</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Hi - we use metrics3-riemann-reporter extensively with Apache Spark.  Spark 2.3 [uses codahale.metrics 3.1.5](https://github.com/apache/spark/blob/branch-2.3/pom.xml#L141) and also [SPARK-22483 changes](https://github.com/apache/spark/commit/9eb7096c47a7e5f98de19512515386b3d0698039) break backwards compatibility with codahale.metrics 3.0.1.

Would it be possible to update this and generate the new artifacts?  I think this might also satisfy Issue [#43](https://github.com/riemann/riemann-java-client/issues/43)?

Thanks!
