### PR TITLE
Enable metric state reporting

### DIFF
--- a/metrics2-riemann-reporter/pom.xml
+++ b/metrics2-riemann-reporter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>riemann-java-client-parent</artifactId>
         <groupId>io.riemann</groupId>
-        <version>0.4.6</version>
+        <version>0.4.7-SNAPSHOT</version>
     </parent>
 
 

--- a/metrics3-riemann-reporter/pom.xml
+++ b/metrics3-riemann-reporter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>riemann-java-client-parent</artifactId>
         <groupId>io.riemann</groupId>
-        <version>0.4.6</version>
+        <version>0.4.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
@@ -42,8 +42,7 @@ import io.riemann.riemann.client.EventDSL;
  * A reporter that submits events to Riemann
  */
 public class RiemannReporter
-    extends
-    ScheduledReporter {
+    extends ScheduledReporter {
 
     /**
      * Returns a new {@link Builder} for {@link RiemannReporter}.
@@ -355,34 +354,36 @@ public class RiemannReporter
 
     private void reportTimer(String name, Timer timer, long timestamp) {
         final Snapshot snapshot = timer.getSnapshot();
+        final TimeUnit timeUnit = TimeUnit
+            .valueOf(getDurationUnit().toUpperCase());
         final EventClosure reporter = newEvent(name, timestamp, timer.getClass()
             .getSimpleName());
 
         reporter.name("max").metric(convertDuration(snapshot.getMax()))
-            .state(valueFilterMap.state(timer, "max")).send();
+            .state(valueFilterMap.state(timer, "max", timeUnit)).send();
         reporter.name("mean").metric(convertDuration(snapshot.getMean()))
-            .state(valueFilterMap.state(timer, "mean")).send();
+            .state(valueFilterMap.state(timer, "mean", timeUnit)).send();
         reporter.name("min").metric(convertDuration(snapshot.getMin()))
-            .state(valueFilterMap.state(timer, "min")).send();
+            .state(valueFilterMap.state(timer, "min", timeUnit)).send();
         reporter.name("stddev").metric(convertDuration(snapshot.getStdDev()))
-            .state(valueFilterMap.state(timer, "stddev")).send();
+            .state(valueFilterMap.state(timer, "stddev", timeUnit)).send();
         reporter.name("p50").metric(convertDuration(snapshot.getMedian()))
-            .state(valueFilterMap.state(timer, "p50")).send();
+            .state(valueFilterMap.state(timer, "p50", timeUnit)).send();
         reporter.name("p75")
             .metric(convertDuration(snapshot.get75thPercentile()))
-            .state(valueFilterMap.state(timer, "p75")).send();
+            .state(valueFilterMap.state(timer, "p75", timeUnit)).send();
         reporter.name("p95")
             .metric(convertDuration(snapshot.get95thPercentile()))
-            .state(valueFilterMap.state(timer, "p95")).send();
+            .state(valueFilterMap.state(timer, "p95", timeUnit)).send();
         reporter.name("p98")
             .metric(convertDuration(snapshot.get98thPercentile()))
-            .state(valueFilterMap.state(timer, "p98")).send();
+            .state(valueFilterMap.state(timer, "p98", timeUnit)).send();
         reporter.name("p99")
             .metric(convertDuration(snapshot.get99thPercentile()))
-            .state(valueFilterMap.state(timer, "p99")).send();
+            .state(valueFilterMap.state(timer, "p99", timeUnit)).send();
         reporter.name("p999")
             .metric(convertDuration(snapshot.get999thPercentile()))
-            .state(valueFilterMap.state(timer, "p999")).send();
+            .state(valueFilterMap.state(timer, "p999", timeUnit)).send();
 
         reportMetered(name, timer, timestamp);
     }

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
@@ -1,48 +1,42 @@
 /*
- * Copyright 2014 Dominic LoBue Copyright 2014 Brandon Seibel Licensed under the
- * Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
- * or agreed to in writing, software distributed under the License is
- * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2014 Dominic LoBue
+ * Copyright 2014 Brandon Seibel
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 
 package com.codahale.metrics.riemann;
 
+import io.riemann.riemann.client.EventDSL;
+import com.codahale.metrics.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metered;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.ScheduledReporter;
-import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.Timer;
-
-import io.riemann.riemann.client.EventDSL;
 
 /**
  * A reporter that submits events to Riemann
  */
-public class RiemannReporter
-    extends ScheduledReporter {
+public class RiemannReporter extends ScheduledReporter {
 
     /**
      * Returns a new {@link Builder} for {@link RiemannReporter}.
@@ -55,33 +49,23 @@ public class RiemannReporter
     }
 
     /**
-     * A builder for {@link RiemannReporter} instances. Defaults to not using a
-     * prefix, using the default clock, converting rates to events/second,
-     * converting durations to milliseconds, and not filtering metrics.
+     * A builder for {@link RiemannReporter} instances. Defaults to not using a prefix, using the
+     * default clock, converting rates to events/second, converting durations to milliseconds, and
+     * not filtering metrics.
      */
     public static class Builder {
-
         private final MetricRegistry registry;
-
         private Clock clock;
-
         private TimeUnit rateUnit;
-
         private TimeUnit durationUnit;
-
         private MetricFilter filter;
-
         private Float ttl;
-
         private String prefix;
-
         private String separator;
-
         private String localHost;
-
         private final List<String> tags;
-
         private ValueFilterMap valueFilterMap = new ValueFilterMap();
+
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -166,11 +150,6 @@ public class RiemannReporter
             return this;
         }
 
-        public Builder withValueFilterMap(ValueFilterMap valueFilterMap) {
-            this.valueFilterMap = valueFilterMap;
-            return this;
-        }
-
         /**
          * Separator between metric name components
          *
@@ -206,43 +185,65 @@ public class RiemannReporter
         }
 
         /**
-         * Builds a {@link RiemannReporter} with the given properties, sending
-         * metrics using the given {@link Riemann} client.
+         * ValueFilterMap to determine states reported with measures.  Defaults to
+         * an empty map which causes "ok" to be the reported state for all measures.
+         * 
+         * @param valueFilterMap {@link ValueFilterMap} with keys equal to measures
+         *        (e.g. "mean"). Values are lists of {@link ValueFilter}s that determine
+         *        the reported state 
+         * @return {@code this}
+         */
+        public Builder withValueFilterMap(ValueFilterMap valueFilterMap) {
+            this.valueFilterMap = valueFilterMap;
+            return this;
+        }
+
+
+        /**
+         * Builds a {@link RiemannReporter} with the given properties, sending metrics using the
+         * given {@link Riemann} client.
          *
          * @param riemann a {@link Riemann} client.
          * @return a {@link RiemannReporter}
          */
         public RiemannReporter build(Riemann riemann) {
-            return new RiemannReporter(registry, riemann, clock, rateUnit,
-                                       durationUnit, ttl, prefix, separator,
-                                       localHost, tags, filter, valueFilterMap);
+            return new RiemannReporter(registry,
+                    riemann,
+                    clock,
+                    rateUnit,
+                    durationUnit,
+                    ttl,
+                    prefix,
+                    separator,
+                    localHost,
+                    tags,
+                    filter,
+                    valueFilterMap);
         }
     }
 
-    private static final Logger log = LoggerFactory
-        .getLogger(RiemannReporter.class);
+    private static final Logger log = LoggerFactory.getLogger(RiemannReporter.class);
 
     private final Riemann riemann;
-
     private final Clock clock;
-
     private final String prefix;
-
     private final String separator;
-
     private final String localHost;
-
     private final List<String> tags;
-
     private final Float ttl;
-
     private final ValueFilterMap valueFilterMap;
 
-    private RiemannReporter(MetricRegistry registry, Riemann riemann,
-                            Clock clock, TimeUnit rateUnit,
-                            TimeUnit durationUnit, Float ttl, String prefix,
-                            String separator, String localHost,
-                            List<String> tags, MetricFilter filter,
+    private RiemannReporter(MetricRegistry registry,
+                            Riemann riemann,
+                            Clock clock,
+                            TimeUnit rateUnit,
+                            TimeUnit durationUnit,
+                            Float ttl,
+                            String prefix,
+                            String separator,
+                            String localHost,
+                            List<String> tags,
+                            MetricFilter filter,
                             ValueFilterMap valueFilterMap) {
         super(registry, "riemann-reporter", filter, rateUnit, durationUnit);
         this.riemann = riemann;
@@ -256,16 +257,14 @@ public class RiemannReporter
     }
 
     private interface EventClosure {
-
         public EventDSL name(String... components);
     }
 
-    private EventClosure newEvent(final String metricName, final long timestamp,
-                                  final String metricType) {
+
+    private EventClosure newEvent(final String metricName, final long timestamp, final String metricType) {
         final String prefix = this.prefix;
         final String separator = this.separator;
         return new EventClosure() {
-
             public EventDSL name(String... components) {
                 EventDSL event = riemann.client.event();
                 if (localHost != null) {
@@ -297,6 +296,7 @@ public class RiemannReporter
         };
     }
 
+
     @Override
     public void report(SortedMap<String, Gauge> gauges,
                        SortedMap<String, Counter> counters,
@@ -305,8 +305,7 @@ public class RiemannReporter
                        SortedMap<String, Timer> timers) {
         final long timestamp = clock.getTime() / 1000;
 
-        log.debug("Reporting metrics: for {} at {}", timestamp,
-                  System.currentTimeMillis());
+        log.debug("Reporting metrics: for {} at {}", timestamp, System.currentTimeMillis());
         // oh it'd be lovely to use Java 7 here
         try {
             riemann.connect();
@@ -354,10 +353,8 @@ public class RiemannReporter
 
     private void reportTimer(String name, Timer timer, long timestamp) {
         final Snapshot snapshot = timer.getSnapshot();
-        final TimeUnit timeUnit = TimeUnit
-            .valueOf(getDurationUnit().toUpperCase());
-        final EventClosure reporter = newEvent(name, timestamp, timer.getClass()
-            .getSimpleName());
+        final EventClosure reporter = newEvent(name, timestamp, timer.getClass().getSimpleName());
+        final TimeUnit timeUnit = TimeUnit.valueOf(getDurationUnit().toUpperCase());
 
         reporter.name("max").metric(convertDuration(snapshot.getMax()))
             .state(valueFilterMap.state(timer, "max", timeUnit)).send();
@@ -389,8 +386,8 @@ public class RiemannReporter
     }
 
     private void reportMetered(String name, Metered meter, long timestamp) {
-        final EventClosure reporter = newEvent(name, timestamp, meter.getClass()
-            .getSimpleName());
+        final EventClosure reporter = newEvent(name, timestamp, meter.getClass().getSimpleName());
+
         reporter.name("count").metric(meter.getCount())
             .state(valueFilterMap.state(meter, "count")).send();
         reporter.name("m1_rate").metric(convertRate(meter.getOneMinuteRate()))
@@ -404,11 +401,9 @@ public class RiemannReporter
             .state(valueFilterMap.state(meter, "mean_rate")).send();
     }
 
-    private void reportHistogram(String name, Histogram histogram,
-                                 long timestamp) {
+    private void reportHistogram(String name, Histogram histogram, long timestamp) {
         final Snapshot snapshot = histogram.getSnapshot();
-        final EventClosure reporter = newEvent(name, timestamp, histogram
-            .getClass().getSimpleName());
+        final EventClosure reporter = newEvent(name, timestamp, histogram.getClass().getSimpleName());
 
         reporter.name("count").metric(histogram.getCount())
             .state(valueFilterMap.state(histogram, "count")).send();
@@ -435,15 +430,13 @@ public class RiemannReporter
     }
 
     private void reportCounter(String name, Counter counter, long timestamp) {
-        final EventClosure reporter = newEvent(name, timestamp, counter
-            .getClass().getSimpleName());
+        final EventClosure reporter = newEvent(name, timestamp, counter.getClass().getSimpleName());
         reporter.name("count").metric(counter.getCount())
             .state(valueFilterMap.state(counter)).send();
     }
 
     private void reportGauge(String name, Gauge gauge, long timestamp) {
-        final EventClosure reporter = newEvent(name, timestamp, gauge.getClass()
-            .getSimpleName());
+        final EventClosure reporter = newEvent(name, timestamp, gauge.getClass().getSimpleName());
         Object o = gauge.getValue();
 
         if (o instanceof Float) {
@@ -461,8 +454,7 @@ public class RiemannReporter
         } else if (o == null) {
             log.debug("Gauge {} has a null value", name);
         } else {
-            log.debug("Gauge {} was of an unknown type: {} ", name,
-                      o.getClass().toString());
+            log.debug("Gauge {} was of an unknown type: {} ", name, o.getClass().toString());
         }
     }
 }

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
@@ -42,7 +42,8 @@ import io.riemann.riemann.client.EventDSL;
  * A reporter that submits events to Riemann
  */
 public class RiemannReporter
-    extends ScheduledReporter {
+    extends
+    ScheduledReporter {
 
     /**
      * Returns a new {@link Builder} for {@link RiemannReporter}.
@@ -81,7 +82,7 @@ public class RiemannReporter
 
         private final List<String> tags;
 
-        private ValueFilterMap stateFilterMap = new ValueFilterMap();
+        private ValueFilterMap valueFilterMap = new ValueFilterMap();
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -166,8 +167,8 @@ public class RiemannReporter
             return this;
         }
 
-        public Builder withStateFilterMap(ValueFilterMap stateFilterMap) {
-            this.stateFilterMap = stateFilterMap;
+        public Builder withValueFilterMap(ValueFilterMap valueFilterMap) {
+            this.valueFilterMap = valueFilterMap;
             return this;
         }
 
@@ -215,7 +216,7 @@ public class RiemannReporter
         public RiemannReporter build(Riemann riemann) {
             return new RiemannReporter(registry, riemann, clock, rateUnit,
                                        durationUnit, ttl, prefix, separator,
-                                       localHost, tags, filter, stateFilterMap);
+                                       localHost, tags, filter, valueFilterMap);
         }
     }
 
@@ -236,14 +237,14 @@ public class RiemannReporter
 
     private final Float ttl;
 
-    private final ValueFilterMap stateFilterMap;
+    private final ValueFilterMap valueFilterMap;
 
     private RiemannReporter(MetricRegistry registry, Riemann riemann,
                             Clock clock, TimeUnit rateUnit,
                             TimeUnit durationUnit, Float ttl, String prefix,
                             String separator, String localHost,
                             List<String> tags, MetricFilter filter,
-                            ValueFilterMap stateFilterMap) {
+                            ValueFilterMap valueFilterMap) {
         super(registry, "riemann-reporter", filter, rateUnit, durationUnit);
         this.riemann = riemann;
         this.clock = clock;
@@ -252,7 +253,7 @@ public class RiemannReporter
         this.localHost = localHost;
         this.tags = tags;
         this.ttl = ttl;
-        this.stateFilterMap = stateFilterMap;
+        this.valueFilterMap = valueFilterMap;
     }
 
     private interface EventClosure {
@@ -358,30 +359,30 @@ public class RiemannReporter
             .getSimpleName());
 
         reporter.name("max").metric(convertDuration(snapshot.getMax()))
-            .state(stateFilterMap.state(timer, "max")).send();
+            .state(valueFilterMap.state(timer, "max")).send();
         reporter.name("mean").metric(convertDuration(snapshot.getMean()))
-            .state(stateFilterMap.state(timer, "mean")).send();
+            .state(valueFilterMap.state(timer, "mean")).send();
         reporter.name("min").metric(convertDuration(snapshot.getMin()))
-            .state(stateFilterMap.state(timer, "min")).send();
+            .state(valueFilterMap.state(timer, "min")).send();
         reporter.name("stddev").metric(convertDuration(snapshot.getStdDev()))
-            .state(stateFilterMap.state(timer, "stddev")).send();
+            .state(valueFilterMap.state(timer, "stddev")).send();
         reporter.name("p50").metric(convertDuration(snapshot.getMedian()))
-            .state(stateFilterMap.state(timer, "p50")).send();
+            .state(valueFilterMap.state(timer, "p50")).send();
         reporter.name("p75")
             .metric(convertDuration(snapshot.get75thPercentile()))
-            .state(stateFilterMap.state(timer, "p75")).send();
+            .state(valueFilterMap.state(timer, "p75")).send();
         reporter.name("p95")
             .metric(convertDuration(snapshot.get95thPercentile()))
-            .state(stateFilterMap.state(timer, "p95")).send();
+            .state(valueFilterMap.state(timer, "p95")).send();
         reporter.name("p98")
             .metric(convertDuration(snapshot.get98thPercentile()))
-            .state(stateFilterMap.state(timer, "p98")).send();
+            .state(valueFilterMap.state(timer, "p98")).send();
         reporter.name("p99")
             .metric(convertDuration(snapshot.get99thPercentile()))
-            .state(stateFilterMap.state(timer, "p99")).send();
+            .state(valueFilterMap.state(timer, "p99")).send();
         reporter.name("p999")
             .metric(convertDuration(snapshot.get999thPercentile()))
-            .state(stateFilterMap.state(timer, "p999")).send();
+            .state(valueFilterMap.state(timer, "p999")).send();
 
         reportMetered(name, timer, timestamp);
     }
@@ -390,16 +391,16 @@ public class RiemannReporter
         final EventClosure reporter = newEvent(name, timestamp, meter.getClass()
             .getSimpleName());
         reporter.name("count").metric(meter.getCount())
-            .state(stateFilterMap.state(meter, "count")).send();
+            .state(valueFilterMap.state(meter, "count")).send();
         reporter.name("m1_rate").metric(convertRate(meter.getOneMinuteRate()))
-            .state(stateFilterMap.state(meter, "m1_rate")).send();
+            .state(valueFilterMap.state(meter, "m1_rate")).send();
         reporter.name("m5_rate").metric(convertRate(meter.getFiveMinuteRate()))
-            .state(stateFilterMap.state(meter, "m5_rate")).send();
+            .state(valueFilterMap.state(meter, "m5_rate")).send();
         reporter.name("m15_rate")
             .metric(convertRate(meter.getFifteenMinuteRate()))
-            .state(stateFilterMap.state(meter, "m15_rate")).send();
+            .state(valueFilterMap.state(meter, "m15_rate")).send();
         reporter.name("mean_rate").metric(convertRate(meter.getMeanRate()))
-            .state(stateFilterMap.state(meter, "mean_rate")).send();
+            .state(valueFilterMap.state(meter, "mean_rate")).send();
     }
 
     private void reportHistogram(String name, Histogram histogram,
@@ -409,34 +410,34 @@ public class RiemannReporter
             .getClass().getSimpleName());
 
         reporter.name("count").metric(histogram.getCount())
-            .state(stateFilterMap.state(histogram, "count")).send();
+            .state(valueFilterMap.state(histogram, "count")).send();
         reporter.name("max").metric(snapshot.getMax())
-            .state(stateFilterMap.state(histogram, "max")).send();
+            .state(valueFilterMap.state(histogram, "max")).send();
         reporter.name("mean").metric(snapshot.getMean())
-            .state(stateFilterMap.state(histogram, "mean")).send();
+            .state(valueFilterMap.state(histogram, "mean")).send();
         reporter.name("min").metric(snapshot.getMin())
-            .state(stateFilterMap.state(histogram, "min")).send();
+            .state(valueFilterMap.state(histogram, "min")).send();
         reporter.name("stddev").metric(snapshot.getStdDev())
-            .state(stateFilterMap.state(histogram, "stddev")).send();
+            .state(valueFilterMap.state(histogram, "stddev")).send();
         reporter.name("p50").metric(snapshot.getMedian())
-            .state(stateFilterMap.state(histogram, "p50")).send();
+            .state(valueFilterMap.state(histogram, "p50")).send();
         reporter.name("p75").metric(snapshot.get75thPercentile())
-            .state(stateFilterMap.state(histogram, "p75")).send();
+            .state(valueFilterMap.state(histogram, "p75")).send();
         reporter.name("p95").metric(snapshot.get95thPercentile())
-            .state(stateFilterMap.state(histogram, "max")).send();
+            .state(valueFilterMap.state(histogram, "max")).send();
         reporter.name("p98").metric(snapshot.get98thPercentile())
-            .state(stateFilterMap.state(histogram, "p95")).send();
+            .state(valueFilterMap.state(histogram, "p95")).send();
         reporter.name("p99").metric(snapshot.get99thPercentile())
-            .state(stateFilterMap.state(histogram, "p99")).send();
+            .state(valueFilterMap.state(histogram, "p99")).send();
         reporter.name("p999").metric(snapshot.get999thPercentile())
-            .state(stateFilterMap.state(histogram, "p999")).send();
+            .state(valueFilterMap.state(histogram, "p999")).send();
     }
 
     private void reportCounter(String name, Counter counter, long timestamp) {
         final EventClosure reporter = newEvent(name, timestamp, counter
             .getClass().getSimpleName());
         reporter.name("count").metric(counter.getCount())
-            .state(stateFilterMap.state(counter)).send();
+            .state(valueFilterMap.state(counter)).send();
     }
 
     private void reportGauge(String name, Gauge gauge, long timestamp) {

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
@@ -101,7 +101,7 @@ public class ValueFilter {
         }
 
         /**
-         * @param inclusive upper upper bound for the interval
+         * @param upper inclusive upper bound for the interval
          * @return Builder instance with upper set inclusively (i.e. upper bound
          *         is included in the interval)
          */
@@ -111,7 +111,7 @@ public class ValueFilter {
         }
 
         /**
-         * @param exclusive lower lower bound for the interval
+         * @param lower exclusive lower bound for the interval
          * @return Builder instance with lower set exclusively (i.e. lower bound
          *         is not included in the interval)
          */
@@ -122,7 +122,7 @@ public class ValueFilter {
         };
 
         /**
-         * @param exclusive upper upper bound for the interval
+         * @param upper exclusive upper bound for the interval
          * @return Builder instance with upper set exclusively (i.e. upper bound
          *         is not included in the interval)
          */

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
@@ -1,17 +1,39 @@
 package com.codahale.metrics.riemann;
 
+/**
+ * Filters values to determine if they fall into a given range via the
+ * {@link #applies(double)} method. Ranges are intervals, with endpoint
+ * inclusion configurable. The {@code state} property implicitly binds values in
+ * the represented range to that state for reporting.
+ * <p>
+ * Instances are created using {@link ValueFilter.Builder}. Endpoints not
+ * specified default to positive or negative infinity, respectively. For
+ * example, {@code new ValueFilter.Builder("critical").withLower(50).build())}
+ * creates a ValueFilter instance that binds "critical" to all values greater
+ * than or equal to 50 and {@code new ValueFilter.Builder("warn")
+ *                          .withUpperExclusive(300)
+ *                          .withLower(100).build())} creates an instance
+ * binding "warn" to values greater than or equal to 100 and strictly less than
+ * 300.
+ */
 public class ValueFilter {
 
+    /** Lower bound of the interval */
     private final double lower;
 
+    /** Upper bound of the interval */
     private final double upper;
 
+    /** Whether or not the upper bound is included */
     private final boolean upperIncluded;
 
+    /** Whether or not the lower bound is included */
     private final boolean lowerIncluded;
 
+    /** State bound to values in this interval */
     private final String state;
 
+    /** Create a ValueFilter instance using the given builder */
     private ValueFilter(Builder builder) {
         this.lower = builder.lower;
         this.upper = builder.upper;
@@ -20,53 +42,102 @@ public class ValueFilter {
         this.state = builder.state;
     }
 
+    /**
+     * Determine whether or not the given value falls within the range
+     * associated with this ValueFilter.
+     * 
+     * @param value value to test
+     * @return true iff value is within the target interval
+     */
     public boolean applies(double value) {
         boolean ret = upperIncluded ? value <= upper : value < upper;
         return ret && (lowerIncluded ? lower <= value : lower < value);
     }
 
+    /**
+     * @return the state bound to values in this ValueFilter
+     */
     public String getState() {
         return state;
     }
 
+    /**
+     * Builder for ValueFilter instances
+     */
     public static class Builder {
 
+        /** Lower bound for the interval */
         private double lower = Double.NEGATIVE_INFINITY;
 
+        /** Upper bound for the interval */
         private double upper = Double.POSITIVE_INFINITY;
 
+        /** Whether or not the upper bound is included in the interval */
         private boolean upperIncluded = true;
 
+        /** Whether or not the lower bound is included in the interval */
         private boolean lowerIncluded = true;
 
+        /** State bound to values in the interval */
         private final String state;
 
+        /**
+         * Create a new builder for ValueFilters bound to the given state
+         * 
+         * @param state state bound to values in the interval
+         */
         public Builder(String state) {
             this.state = state;
         }
 
+        /**
+         * @param lower inclusive lower bound for the interval
+         * @return Builder instance with lower set inclusively (i.e. lower bound
+         *         is included in the interval)
+         */
         public Builder withLower(double lower) {
             this.lower = lower;
             return this;
         }
 
+        /**
+         * @param inclusive upper upper bound for the interval
+         * @return Builder instance with upper set inclusively (i.e. upper bound
+         *         is included in the interval)
+         */
         public Builder withUpper(double upper) {
             this.upper = upper;
             return this;
         }
 
+        /**
+         * @param exclusive lower lower bound for the interval
+         * @return Builder instance with lower set exclusively (i.e. lower bound
+         *         is not included in the interval)
+         */
         public Builder withLowerExclusive(double lower) {
             this.lower = lower;
             this.lowerIncluded = false;
             return this;
         };
 
+        /**
+         * @param exclusive upper upper bound for the interval
+         * @return Builder instance with upper set exclusively (i.e. upper bound
+         *         is not included in the interval)
+         */
         public Builder withUpperExclusive(double upper) {
             this.upper = upper;
             this.upperIncluded = false;
             return this;
         }
 
+        /**
+         * Build a ValueFilter using this Builder instance
+         * 
+         * @return ValueFilter with properties determined by those of this
+         *         Builder
+         */
         public ValueFilter build() {
             return new ValueFilter(this);
         }

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
@@ -22,7 +22,7 @@ public class ValueFilter {
 
     public boolean applies(double value) {
         boolean ret = upperIncluded ? value <= upper : value < upper;
-        return ret && lowerIncluded ? lower <= value : lower < value;
+        return ret && (lowerIncluded ? lower <= value : lower < value);
     }
 
     public String getState() {
@@ -31,15 +31,15 @@ public class ValueFilter {
 
     public static class Builder {
 
-        private double lower = Double.MIN_VALUE;
+        private double lower = Double.NEGATIVE_INFINITY;
 
-        private Double upper = Double.MAX_VALUE;
+        private double upper = Double.POSITIVE_INFINITY;
 
         private boolean upperIncluded = true;
 
         private boolean lowerIncluded = true;
 
-        private String state = "ok";
+        private final String state;
 
         public Builder(String state) {
             this.state = state;

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilter.java
@@ -1,0 +1,74 @@
+package com.codahale.metrics.riemann;
+
+public class ValueFilter {
+
+    private final double lower;
+
+    private final double upper;
+
+    private final boolean upperIncluded;
+
+    private final boolean lowerIncluded;
+
+    private final String state;
+
+    private ValueFilter(Builder builder) {
+        this.lower = builder.lower;
+        this.upper = builder.upper;
+        this.upperIncluded = builder.upperIncluded;
+        this.lowerIncluded = builder.lowerIncluded;
+        this.state = builder.state;
+    }
+
+    public boolean applies(double value) {
+        boolean ret = upperIncluded ? value <= upper : value < upper;
+        return ret && lowerIncluded ? lower <= value : lower < value;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public static class Builder {
+
+        private double lower = Double.MIN_VALUE;
+
+        private Double upper = Double.MAX_VALUE;
+
+        private boolean upperIncluded = true;
+
+        private boolean lowerIncluded = true;
+
+        private String state = "ok";
+
+        public Builder(String state) {
+            this.state = state;
+        }
+
+        public Builder withLower(double lower) {
+            this.lower = lower;
+            return this;
+        }
+
+        public Builder withUpper(double upper) {
+            this.upper = upper;
+            return this;
+        }
+
+        public Builder withLowerExclusive(double lower) {
+            this.lower = lower;
+            this.lowerIncluded = false;
+            return this;
+        };
+
+        public Builder withUpperExclusive(double upper) {
+            this.upper = upper;
+            this.upperIncluded = false;
+            return this;
+        }
+
+        public ValueFilter build() {
+            return new ValueFilter(this);
+        }
+    }
+}

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilterMap.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilterMap.java
@@ -1,0 +1,263 @@
+package com.codahale.metrics.riemann;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+public class ValueFilterMap {
+
+    // Message constants
+    public static final String MAX = "max";
+
+    public static final String MEAN = "mean";
+
+    public static final String MIN = "min";
+
+    public static final String STDDEV = "stddev";
+
+    public static final String P50 = "p50";
+
+    public static final String P75 = "p75";
+
+    public static final String P95 = "p95";
+
+    public static final String P98 = "p98";
+
+    public static final String P99 = "p99";
+
+    public static final String P999 = "p999";
+
+    public static final String COUNT = "count";
+
+    public static final String M1_RATE = "m1_rate";
+
+    public static final String M5_RATE = "m5_rate";
+
+    public static final String M15_RATE = "m15_rate";
+
+    public static final String MEAN_RATE = "mean_rate";
+
+    // TODO: when Java 8 is available, replace this bloated setup with lambdas
+    //
+    /** Implementations extract specific values from snapshots */
+    interface SnapValue {
+
+        /** @return the snapshot value that this lamba-like thing is keyed on */
+        double value(Snapshot snapshot);
+    }
+
+    /** Implementations extract specific statistics from metered impls */
+    interface MeteredValue {
+
+        /** @return the metered value that this lamba-like thing is keyed on */
+        double value(Metered metered);
+    }
+
+    /**
+     * Map with keys equal to snapshot statistics names and values lambda-like
+     * objects that extract the named statistic - statically initialized
+     */
+    private static final Map<String, SnapValue> snapValueMap = new HashMap<String, SnapValue>();
+
+    /**
+     * Map with keys equal to metered value names and values lambda-like objects
+     * that extract the named metrics - statically initialized
+     */
+    private static final Map<String, MeteredValue> meteredValueMap = new HashMap<String, MeteredValue>();
+
+    /** Loads lambda-like maps used to extract values from metrics */
+    static {
+        snapValueMap.put(MAX, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.getMax();
+            }
+        });
+        snapValueMap.put(MEAN, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.getMean();
+            }
+        });
+        snapValueMap.put(MIN, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.getMin();
+            }
+        });
+        snapValueMap.put(STDDEV, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.getStdDev();
+            }
+        });
+        snapValueMap.put(P50, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.getMedian();
+            }
+        });
+        snapValueMap.put(P75, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.get75thPercentile();
+            }
+        });
+        snapValueMap.put(P95, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.get95thPercentile();
+            }
+        });
+        snapValueMap.put(P98, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.get98thPercentile();
+            }
+        });
+        snapValueMap.put(P99, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.get99thPercentile();
+            }
+        });
+        snapValueMap.put(P999, new SnapValue() {
+
+            public double value(Snapshot snapshot) {
+                return snapshot.get999thPercentile();
+            }
+        });
+
+        meteredValueMap.put(COUNT, new MeteredValue() {
+
+            public double value(Metered metered) {
+                return metered.getCount();
+            }
+        });
+        meteredValueMap.put(M1_RATE, new MeteredValue() {
+
+            public double value(Metered metered) {
+                return metered.getOneMinuteRate();
+            }
+        });
+        meteredValueMap.put(M5_RATE, new MeteredValue() {
+
+            public double value(Metered metered) {
+                return metered.getFiveMinuteRate();
+            }
+        });
+        meteredValueMap.put(M15_RATE, new MeteredValue() {
+
+            public double value(Metered metered) {
+                return metered.getFifteenMinuteRate();
+            }
+        });
+        meteredValueMap.put(MEAN_RATE, new MeteredValue() {
+
+            public double value(Metered metered) {
+                return metered.getMeanRate();
+            }
+        });
+    }
+
+    /**
+     * If m is a Metric, then filterMapMap.get(m) is a map with keys equal to
+     * measures (constants above) and values equal to ValueFilter instances.
+     * ValueFilters mapped to measures are applied in determining the state
+     * associated with the given measure reported to Riemann in m's report.
+     */
+    private final Map<Metric, Map<String, List<ValueFilter>>> filterMapMap = new ConcurrentHashMap<Metric, Map<String, List<ValueFilter>>>();
+
+    public ValueFilterMap() {
+        super();
+    }
+
+    public ValueFilterMap add(Metric metric, String measure,
+                              ValueFilter filter) {
+        Map<String, List<ValueFilter>> filterMap = filterMapMap.get(metric);
+        List<ValueFilter> filterList;
+        if (filterMap == null) {
+            filterMap = new HashMap<String, List<ValueFilter>>();
+            filterMapMap.put(metric, filterMap);
+        }
+        filterList = filterMap.get(measure);
+        if (filterList == null) {
+            filterList = new ArrayList<ValueFilter>();
+            filterMap.put(measure, filterList);
+        }
+        filterList.add(filter);
+        return this;
+    }
+
+    public List<ValueFilter> get(Metric metric, String measure) {
+        final Map<String, List<ValueFilter>> filterMap = filterMapMap
+            .get(metric);
+        if (filterMap == null) {
+            return null;
+        }
+        return filterMap.get(measure);
+    }
+
+    public String state(Timer timer, String measure) {
+        final Snapshot snap = timer.getSnapshot();
+        final double value = snapValueMap.get(measure).value(snap);
+        return state(get(timer, measure), value);
+    }
+
+    public String state(Histogram histogram, String measure) {
+        double value;
+        if (measure.equals(COUNT)) {
+            value = histogram.getCount();
+        } else {
+            final Snapshot snap = histogram.getSnapshot();
+            value = snapValueMap.get(measure).value(snap);
+        }
+        return state(get(histogram, measure), value);
+    }
+
+    public String state(Metered metered, String measure) {
+        final double value = meteredValueMap.get(measure).value(metered);
+        return state(get(metered, measure), value);
+    }
+
+    public String state(Counter counter) {
+        final double value = counter.getCount();
+        return state(get(counter, "count"), value);
+    }
+
+    public synchronized void clear(Metric metric) {
+        final Map<String, List<ValueFilter>> filters = filterMapMap.get(metric);
+        for (Entry<String, List<ValueFilter>> entry : filters.entrySet()) {
+            entry.getValue().clear();
+        }
+        filters.clear();
+    }
+
+    public synchronized void clear() {
+        for (Metric metric : filterMapMap.keySet()) {
+            clear(metric);
+        }
+    }
+
+    private String state(List<ValueFilter> filters, double value) {
+        String ret = "ok";
+        if (filters != null) {
+            for (ValueFilter filter : filters) {
+                if (filter.applies(value)) {
+                    ret = filter.getState();
+                }
+            }
+        }
+        return ret;
+    }
+}

--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilterMap.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/ValueFilterMap.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
@@ -263,11 +264,14 @@ public class ValueFilterMap {
      * @param timer timer instance
      * @param measure name of the value reported by the timer whose reported
      *        state is sought
-     * @return
+     * @param durationUnit TimeUnit to convert timer's native (nanosecond)
+     *        measurements to
+     * @return state corresponding to the given measure
      */
-    public String state(Timer timer, String measure) {
+    public String state(Timer timer, String measure, TimeUnit durationUnit) {
         final Snapshot snap = timer.getSnapshot();
-        final double value = snapValueMap.get(measure).value(snap);
+        final double value = snapValueMap.get(measure).value(snap) /
+                             durationUnit.toNanos(1);
         return state(getFilterList(timer, measure), value);
     }
 

--- a/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
+++ b/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
@@ -68,21 +68,21 @@ public class RiemannReporterTest {
 
     private final MetricRegistry registry = mock(MetricRegistry.class);
 
-    private final ValueFilterMap stateFilterMap = new ValueFilterMap();
+    private final ValueFilterMap valueFilterMap = new ValueFilterMap();
 
     private final RiemannReporter reporter = RiemannReporter
         .forRegistry(registry).withClock(clock).prefixedWith("prefix")
         .convertRatesTo(TimeUnit.SECONDS)
         .convertDurationsTo(TimeUnit.MILLISECONDS).filter(MetricFilter.ALL)
         .useSeparator("|").localHost(localHost).withTtl(ttl).tags(tags)
-        .withStateFilterMap(stateFilterMap).build(riemann);
+        .withValueFilterMap(valueFilterMap).build(riemann);
 
     @Before
     public void setUp()
         throws Exception {
         when(clock.getTime()).thenReturn(timestamp * 1000);
         when(client.event()).thenReturn(eventDSL);
-        stateFilterMap.clear();
+        valueFilterMap.clear();
     }
 
     @Test
@@ -217,7 +217,7 @@ public class RiemannReporterTest {
         throws Exception {
         final Counter counter = mock(Counter.class);
         // Warn on over 50, critical over 150
-        stateFilterMap
+        valueFilterMap
             .add(counter, "count",
                  new ValueFilter.Builder("warn").withLower(50).build())
             .add(counter, "count",
@@ -308,7 +308,7 @@ public class RiemannReporterTest {
     public void reportsTimers()
         throws Exception {
         final Timer timer = mock(Timer.class);
-        stateFilterMap
+        valueFilterMap
             .add(timer, ValueFilterMap.MAX,
                  new ValueFilter.Builder("critical").withLower(50).build())
             .add(timer, ValueFilterMap.MEAN, new ValueFilter.Builder("warn")

--- a/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
+++ b/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
@@ -219,9 +219,9 @@ public class RiemannReporterTest {
         // Warn on over 50, critical over 150
         valueFilterMap
             .addFilter(counter, "count",
-                 new ValueFilter.Builder("warn").withLower(50).build())
-            .addFilter(counter, "count",
-                 new ValueFilter.Builder("critical").withLower(150).build());
+                       new ValueFilter.Builder("warn").withLower(50).build())
+            .addFilter(counter, "count", new ValueFilter.Builder("critical")
+                .withLower(150).build());
         // Value is 100, so should be warn
         when(counter.getCount()).thenReturn(100L);
 
@@ -308,11 +308,12 @@ public class RiemannReporterTest {
     public void reportsTimers()
         throws Exception {
         final Timer timer = mock(Timer.class);
-        valueFilterMap
-            .addFilter(timer, ValueFilterMap.MAX,
-                 new ValueFilter.Builder("critical").withLower(50).build())
-            .addFilter(timer, ValueFilterMap.MEAN, new ValueFilter.Builder("warn")
-                .withUpperExclusive(300000000).withLower(100000000).build());
+        valueFilterMap.addFilter(timer, ValueFilterMap.MAX,
+                                 new ValueFilter.Builder("critical")
+                                     .withLower(50).build())
+            .addFilter(timer, ValueFilterMap.MEAN,
+                       new ValueFilter.Builder("warn").withUpperExclusive(300)
+                           .withLower(100).build());
         when(timer.getCount()).thenReturn(1L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);

--- a/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
+++ b/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
@@ -1,87 +1,117 @@
 package com.codahale.metrics.riemann;
 
-import io.riemann.riemann.client.IRiemannClient;
-import io.riemann.riemann.client.EventDSL;
-import io.riemann.riemann.client.Promise;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
-import com.codahale.metrics.*;
-import com.codahale.metrics.Timer;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.mockito.Mockito.*;
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+import io.riemann.riemann.client.EventDSL;
+import io.riemann.riemann.client.IRiemannClient;
+import io.riemann.riemann.client.Promise;
 
 public class RiemannReporterTest {
+
     private final long timestamp = 1000198;
+
     private final List<String> tags = Arrays.asList("taga", "tagb");
+
     private final float ttl = 100;
+
     private final String localHost = "ME";
+
     private final Clock clock = mock(Clock.class);
+
     private final EventDSL eventDSL = mock(EventDSL.class, new Answer() {
-     public Object answer(InvocationOnMock invocation) {
-       if (invocation.getMethod().getName() == "send") {
-         // We don't actually look for completion of the promise.
-         return new Promise();
-       } else {
-         // Builder-style continuation
-         return invocation.getMock();
-       }
-     }
+
+        public Object answer(InvocationOnMock invocation) {
+            if (invocation.getMethod().getName() == "send") {
+                // We don't actually look for completion of the promise.
+                return new Promise();
+            } else {
+                // Builder-style continuation
+                return invocation.getMock();
+            }
+        }
     });
+
     private final IRiemannClient client = mock(IRiemannClient.class);
+
     private final Riemann riemann = spy(new Riemann(client));
+
     private final MetricRegistry registry = mock(MetricRegistry.class);
-    private final RiemannReporter reporter = RiemannReporter.forRegistry(registry)
-                                                              .withClock(clock)
-                                                              .prefixedWith("prefix")
-                                                              .convertRatesTo(TimeUnit.SECONDS)
-                                                              .convertDurationsTo(TimeUnit.MILLISECONDS)
-                                                              .filter(MetricFilter.ALL)
-                                                              .useSeparator("|")
-                                                              .localHost(localHost)
-                                                              .withTtl(ttl)
-                                                              .tags(tags)
-                                                              .build(riemann);
+
+    private final ValueFilterMap stateFilterMap = new ValueFilterMap();
+
+    private final RiemannReporter reporter = RiemannReporter
+        .forRegistry(registry).withClock(clock).prefixedWith("prefix")
+        .convertRatesTo(TimeUnit.SECONDS)
+        .convertDurationsTo(TimeUnit.MILLISECONDS).filter(MetricFilter.ALL)
+        .useSeparator("|").localHost(localHost).withTtl(ttl).tags(tags)
+        .withStateFilterMap(stateFilterMap).build(riemann);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp()
+        throws Exception {
         when(clock.getTime()).thenReturn(timestamp * 1000);
         when(client.event()).thenReturn(eventDSL);
+        stateFilterMap.clear();
     }
 
     @Test
-    public void uniqueEventsFromClosure() throws Exception {
+    public void uniqueEventsFromClosure()
+        throws Exception {
         final Meter meter = mock(Meter.class);
-        reporter.report(this.<Gauge>map(),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map("meter", meter),
-                        this.<Timer>map());
+        reporter.report(this.<Gauge> map(), this.<Counter> map(),
+                        this.<Histogram> map(),
+                        this.<Meter> map("meter", meter), this.<Timer> map());
 
         verify(client, times(5)).event();
     }
 
     @Test
-    public void doesNotReportStringGaugeValues() throws Exception {
+    public void doesNotReportStringGaugeValues()
+        throws Exception {
         reportGauge("value");
         verifyNoReporting();
     }
 
     @Test
-    public void doesNotReportNullGaugeValues() throws Exception {
+    public void doesNotReportNullGaugeValues()
+        throws Exception {
         reportGauge(null);
         verifyNoReporting();
     }
 
-    private void verifyNoReporting() throws IOException {
+    private void verifyNoReporting()
+        throws IOException {
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
         inOrder.verify(client, never()).event();
@@ -91,99 +121,91 @@ public class RiemannReporterTest {
     }
 
     private void reportGauge(Object value) {
-        reporter.report(map("gauge", gauge(value)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+        reporter.report(map("gauge", gauge(value)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
     }
 
     @Test
-    public void reportsByteGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge((byte) 1)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+    public void reportsByteGaugeValues()
+        throws Exception {
+        reporter.report(map("gauge", gauge((byte) 1)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|gauge", (byte) 1);
+        verifyInOrder(inOrder, "prefix|gauge", (byte) 1, null);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsShortGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge((short) 1)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+    public void reportsShortGaugeValues()
+        throws Exception {
+        reporter.report(map("gauge", gauge((short) 1)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|gauge", (short) 1);
+        verifyInOrder(inOrder, "prefix|gauge", (short) 1, null);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsIntegerGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+    public void reportsIntegerGaugeValues()
+        throws Exception {
+        reporter.report(map("gauge", gauge(1)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|gauge", 1);
+        verifyInOrder(inOrder, "prefix|gauge", 1, null);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsLongGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1L)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+    public void reportsLongGaugeValues()
+        throws Exception {
+        reporter.report(map("gauge", gauge(1L)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|gauge", 1L);
+        verifyInOrder(inOrder, "prefix|gauge", 1L, null);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsFloatGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1f)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+    public void reportsFloatGaugeValues()
+        throws Exception {
+        reporter.report(map("gauge", gauge(1.1f)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|gauge", 1.1f);
+        verifyInOrder(inOrder, "prefix|gauge", 1.1f, null);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsDoubleGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1)),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+    public void reportsDoubleGaugeValues()
+        throws Exception {
+        reporter.report(map("gauge", gauge(1.1)), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|gauge", 1.1);
+        verifyInOrder(inOrder, "prefix|gauge", 1.1, null);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
 
@@ -191,25 +213,33 @@ public class RiemannReporterTest {
     }
 
     @Test
-    public void reportsCounters() throws Exception {
+    public void reportsCounters()
+        throws Exception {
         final Counter counter = mock(Counter.class);
+        // Warn on over 50, critical over 150
+        stateFilterMap
+            .add(counter, "count",
+                 new ValueFilter.Builder("warn").withLower(50).build())
+            .add(counter, "count",
+                 new ValueFilter.Builder("critical").withLower(150).build());
+        // Value is 100, so should be warn
         when(counter.getCount()).thenReturn(100L);
 
-        reporter.report(this.<Gauge>map(),
-                        this.<Counter>map("counter", counter),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+        reporter.report(this.<Gauge> map(),
+                        this.<Counter> map("counter", counter),
+                        this.<Histogram> map(), this.<Meter> map(),
+                        this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|counter|count", 100L);
+        verifyInOrder(inOrder, "prefix|counter|count", 100L, "warn");
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsHistograms() throws Exception {
+    public void reportsHistograms()
+        throws Exception {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
 
@@ -227,32 +257,31 @@ public class RiemannReporterTest {
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
-                        this.<Counter>map(),
-                        this.<Histogram>map("histogram", histogram),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+        reporter.report(this.<Gauge> map(), this.<Counter> map(),
+                        this.<Histogram> map("histogram", histogram),
+                        this.<Meter> map(), this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|histogram|count", 1L);
-        verifyInOrder(inOrder, "prefix|histogram|max", 2L);
-        verifyInOrder(inOrder, "prefix|histogram|mean", 3.0);
-        verifyInOrder(inOrder, "prefix|histogram|min", 4L);
-        verifyInOrder(inOrder, "prefix|histogram|stddev", 5.0);
-        verifyInOrder(inOrder, "prefix|histogram|p50", 6.0);
-        verifyInOrder(inOrder, "prefix|histogram|p75", 7.0);
-        verifyInOrder(inOrder, "prefix|histogram|p95", 8.0);
-        verifyInOrder(inOrder, "prefix|histogram|p98", 9.0);
-        verifyInOrder(inOrder, "prefix|histogram|p99", 10.0);
-        verifyInOrder(inOrder, "prefix|histogram|p999", 11.0);
+        verifyInOrder(inOrder, "prefix|histogram|count", 1L, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|max", 2L, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|mean", 3.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|min", 4L, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|stddev", 5.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|p50", 6.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|p75", 7.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|p95", 8.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|p98", 9.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|p99", 10.0, "ok");
+        verifyInOrder(inOrder, "prefix|histogram|p999", 11.0, "ok");
 
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsMeters() throws Exception {
+    public void reportsMeters()
+        throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
         when(meter.getOneMinuteRate()).thenReturn(2.0);
@@ -260,26 +289,30 @@ public class RiemannReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
         when(meter.getMeanRate()).thenReturn(5.0);
 
-        reporter.report(this.<Gauge>map(),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map("meter", meter),
-                        this.<Timer>map());
+        reporter.report(this.<Gauge> map(), this.<Counter> map(),
+                        this.<Histogram> map(),
+                        this.<Meter> map("meter", meter), this.<Timer> map());
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|meter|count", 1L);
-        verifyInOrder(inOrder, "prefix|meter|m1_rate", 2.0);
-        verifyInOrder(inOrder, "prefix|meter|m5_rate", 3.0);
-        verifyInOrder(inOrder, "prefix|meter|m15_rate", 4.0);
-        verifyInOrder(inOrder, "prefix|meter|mean_rate", 5.0);
+        verifyInOrder(inOrder, "prefix|meter|count", 1L, "ok");
+        verifyInOrder(inOrder, "prefix|meter|m1_rate", 2.0, "ok");
+        verifyInOrder(inOrder, "prefix|meter|m5_rate", 3.0, "ok");
+        verifyInOrder(inOrder, "prefix|meter|m15_rate", 4.0, "ok");
+        verifyInOrder(inOrder, "prefix|meter|mean_rate", 5.0, "ok");
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
-    public void reportsTimers() throws Exception {
+    public void reportsTimers()
+        throws Exception {
         final Timer timer = mock(Timer.class);
+        stateFilterMap
+            .add(timer, ValueFilterMap.MAX,
+                 new ValueFilter.Builder("critical").withLower(50).build())
+            .add(timer, ValueFilterMap.MEAN, new ValueFilter.Builder("warn")
+                .withUpperExclusive(200).withLower(100).build());
         when(timer.getCount()).thenReturn(1L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
@@ -288,42 +321,47 @@ public class RiemannReporterTest {
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
-        when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+        when(snapshot.getMean())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
         when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
-        when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
-        when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
-        when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
-        when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
-        when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
-        when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
-        when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS
-                                                                        .toNanos(1000));
+        when(snapshot.getStdDev())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+        when(snapshot.getMedian())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+        when(snapshot.get75thPercentile())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+        when(snapshot.get95thPercentile())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+        when(snapshot.get98thPercentile())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+        when(snapshot.get99thPercentile())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+        when(snapshot.get999thPercentile())
+            .thenReturn((double) TimeUnit.MILLISECONDS.toNanos(1000));
 
         when(timer.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
+        reporter.report(this.<Gauge> map(), this.<Counter> map(),
+                        this.<Histogram> map(), this.<Meter> map(),
                         map("timer", timer));
 
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
-        verifyInOrder(inOrder, "prefix|timer|max", 100.00);
-        verifyInOrder(inOrder, "prefix|timer|mean", 200.00);
-        verifyInOrder(inOrder, "prefix|timer|min", 300.00);
-        verifyInOrder(inOrder, "prefix|timer|stddev", 400.00);
-        verifyInOrder(inOrder, "prefix|timer|p50", 500.00);
-        verifyInOrder(inOrder, "prefix|timer|p75", 600.00);
-        verifyInOrder(inOrder, "prefix|timer|p95", 700.00);
-        verifyInOrder(inOrder, "prefix|timer|p98", 800.00);
-        verifyInOrder(inOrder, "prefix|timer|p99", 900.00);
-        verifyInOrder(inOrder, "prefix|timer|p999", 1000.00);
-        verifyInOrder(inOrder, "prefix|timer|count", 1L);
-        verifyInOrder(inOrder, "prefix|timer|m1_rate", 3.0);
-        verifyInOrder(inOrder, "prefix|timer|m5_rate", 4.0);
-        verifyInOrder(inOrder, "prefix|timer|m15_rate", 5.0);
-        verifyInOrder(inOrder, "prefix|timer|mean_rate", 2.0);
+        verifyInOrder(inOrder, "prefix|timer|max", 100.00, "critical");
+        verifyInOrder(inOrder, "prefix|timer|mean", 200.00, "warn");
+        verifyInOrder(inOrder, "prefix|timer|min", 300.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|stddev", 400.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|p50", 500.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|p75", 600.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|p95", 700.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|p98", 800.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|p99", 900.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|p999", 1000.00, "ok");
+        verifyInOrder(inOrder, "prefix|timer|count", 1L, "ok");
+        verifyInOrder(inOrder, "prefix|timer|m1_rate", 3.0, "ok");
+        verifyInOrder(inOrder, "prefix|timer|m5_rate", 4.0, "ok");
+        verifyInOrder(inOrder, "prefix|timer|m15_rate", 5.0, "ok");
+        verifyInOrder(inOrder, "prefix|timer|mean_rate", 2.0, "ok");
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
     }
@@ -344,7 +382,9 @@ public class RiemannReporterTest {
         return gauge;
     }
 
-    private void verifyInOrder(InOrder inOrder, String service, Object metric) throws Exception {
+    private void verifyInOrder(InOrder inOrder, String service, Object metric,
+                               String state)
+        throws Exception {
         inOrder.verify(client).event();
         inOrder.verify(eventDSL).host(localHost);
         inOrder.verify(eventDSL).ttl(ttl);
@@ -366,6 +406,10 @@ public class RiemannReporterTest {
             inOrder.verify(eventDSL).metric((Long) metric);
         } else {
             throw new RuntimeException();
+        }
+
+        if (state != null) {
+            inOrder.verify(eventDSL).state(state);
         }
 
         inOrder.verify(eventDSL).send();

--- a/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
+++ b/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
@@ -218,9 +218,9 @@ public class RiemannReporterTest {
         final Counter counter = mock(Counter.class);
         // Warn on over 50, critical over 150
         valueFilterMap
-            .add(counter, "count",
+            .addFilter(counter, "count",
                  new ValueFilter.Builder("warn").withLower(50).build())
-            .add(counter, "count",
+            .addFilter(counter, "count",
                  new ValueFilter.Builder("critical").withLower(150).build());
         // Value is 100, so should be warn
         when(counter.getCount()).thenReturn(100L);
@@ -309,10 +309,10 @@ public class RiemannReporterTest {
         throws Exception {
         final Timer timer = mock(Timer.class);
         valueFilterMap
-            .add(timer, ValueFilterMap.MAX,
+            .addFilter(timer, ValueFilterMap.MAX,
                  new ValueFilter.Builder("critical").withLower(50).build())
-            .add(timer, ValueFilterMap.MEAN, new ValueFilter.Builder("warn")
-                .withUpperExclusive(200).withLower(100).build());
+            .addFilter(timer, ValueFilterMap.MEAN, new ValueFilter.Builder("warn")
+                .withUpperExclusive(300000000).withLower(100000000).build());
         when(timer.getCount()).thenReturn(1L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);

--- a/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/ValueFilterTest.java
+++ b/metrics3-riemann-reporter/src/test/java/com/codahale/metrics/riemann/ValueFilterTest.java
@@ -1,0 +1,25 @@
+package com.codahale.metrics.riemann;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ValueFilterTest {
+
+    @Test
+    public void testApplies() {
+        final ValueFilter warnFilter = new ValueFilter.Builder("warn")
+            .withLower(900).withUpper(1000).build();
+        final ValueFilter criticalFilter = new ValueFilter.Builder("critical")
+            .withLowerExclusive(1000).build();
+        final ValueFilter halfOpenFilter = new ValueFilter.Builder("warn")
+            .withUpperExclusive(300).withLower(100).build();
+        assertTrue(warnFilter.applies(920));
+        assertFalse(warnFilter.applies(1001));
+        assertTrue(criticalFilter.applies(1001));
+        assertFalse(criticalFilter.applies(950));
+        assertTrue(halfOpenFilter.applies(200));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.riemann</groupId>
     <artifactId>riemann-java-client-parent</artifactId>
-    <version>0.4.6</version>
+    <version>0.4.7-SNAPSHOT</version>
     <modules>
         <module>riemann-java-client</module>
         <module>metrics2-riemann-reporter</module>

--- a/riemann-java-client/pom.xml
+++ b/riemann-java-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>riemann-java-client-parent</artifactId>
         <groupId>io.riemann</groupId>
-        <version>0.4.6</version>
+        <version>0.4.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/riemann-java-client/pom.xml
+++ b/riemann-java-client/pom.xml
@@ -32,11 +32,10 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>2.6.1</version>
-            <scope>compile</scope>
-        </dependency>
+  <groupId>com.google.protobuf</groupId>
+  <artifactId>protobuf-java</artifactId>
+  <version>3.5.1</version>
+</dependency>
 
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
Currently, there is no way to enable metrics reports to include state values based on the values of the metrics.  This PR adds support for computation and reporting of metric states.  The implementation associates ranges of values with user-defined states, defaulting to "ok" if no filters have been set up or none of the associated filters applies.

This PR also bumps the version number to 0.4.7-SNAPSHOT and upgrades the Google protocol buffer version.